### PR TITLE
[#38] don't show api tab if "noAPi" property is true

### DIFF
--- a/src/data/api.js
+++ b/src/data/api.js
@@ -111,7 +111,7 @@ const api = {
         "ff-template": {
             path: "ff-template",
             title: "Template",
-            noApi: true  // TODO find out what this is for and remove if not needed
+            noApi: true
         },
         "ff-checkout-tracking": {
             path: "ff-checkout-tracking",

--- a/src/views/api-view.js
+++ b/src/views/api-view.js
@@ -108,7 +108,9 @@ class ApiView extends ViewMixin(ReduxMixin(PolymerElement)) {
                 <paper-tabs selected="{{activeTab}}" attr-for-selected="name">
                     <paper-tab name="docs">Documentation</paper-tab>
                     <paper-tab name="demo">Demo</paper-tab>
+                    <template is="dom-if" if="{{api}}">
                     <paper-tab name="api">Api</paper-tab>
+                    </template>
                 </paper-tabs>
             </app-toolbar>
         </template>
@@ -164,8 +166,16 @@ class ApiView extends ViewMixin(ReduxMixin(PolymerElement)) {
                 type: Boolean,
                 statePath: 'app.drawerOpened',
                 observer: '_toggleDrawer'
+            },
+            api:{
+                type: Boolean,
+                computed: 'computeApi(subpage, data)'
             }
         }
+    }
+
+    computeApi(pageName, data) {
+        if(pageName && data) return !data.pages[pageName].noApi;
     }
 
     connectedCallback() {


### PR DESCRIPTION
fixes #38 

There is a `noApi` property in `api.js` which apparently was intended to prevent the API tab from being shown on the documentation page, but it was never checked, hence #38 

I added a check to fix this issue, now `noApi: true` will prevent the rendering of an api tab.