### PR TITLE
[#62] implement marked-element according to its current documentation

### DIFF
--- a/src/views/api-view.js
+++ b/src/views/api-view.js
@@ -120,9 +120,8 @@ class ApiView extends ViewMixin(ReduxMixin(PolymerElement)) {
 
             <!--Documentation-->
             <marked-element on-syntax-highlight="_addHiglightJs" name="docs">
-                <div slot="markdown-html">
-                    <script type="text/markdown" src="{{filePath}}"></script>
-                </div>
+                <div slot="markdown-html"></div>
+                <script type="text/markdown" src$="[[filePath]]"></script>
             </marked-element>
 
             <!--Demo-->
@@ -138,9 +137,8 @@ class ApiView extends ViewMixin(ReduxMixin(PolymerElement)) {
 
             <!--API-->
             <marked-element id="api_markdown" name="api" on-syntax-highlight="_addHiglightJs">
-                <div slot="markdown-html">
-                    <script type="text/markdown" src="{{apiPath}}"></script>
-                </div>
+                <div slot="markdown-html"></div>
+                <script type="text/markdown" src$="[[apiPath]]"></script>
             </marked-element>
         </iron-pages>
     </div>

--- a/src/views/documentation-view.js
+++ b/src/views/documentation-view.js
@@ -68,9 +68,8 @@ class DocumentationView extends ViewMixin(ReduxMixin(PolymerElement)) {
     <div id="markdown-wrapper">
         <br>
         <marked-element on-syntax-highlight="_addHiglightJs">
-            <div slot="markdown-html">
-                <script type="text/markdown" src="{{filePath}}"></script>
-            </div>
+            <div slot="markdown-html"></div>
+            <script type="text/markdown" src$="[[filePath]]"></script>
         </marked-element>
     </div>
 </app-drawer-layout>

--- a/src/views/download-view.js
+++ b/src/views/download-view.js
@@ -116,9 +116,8 @@ class DownloadView extends PolymerElement {
 
             <paper-dialog-scrollable style="margin: 0px">
                 <marked-element id="api_markdown" name="/api" on-syntax-highlight="_addHiglightJs">
-                    <div slot="markdown-html">
-                        <script type="text/markdown" src="{{markdownFilePath}}"></script>
-                    </div>
+                    <div slot="markdown-html"></div>
+                    <script type="text/markdown" src$="[[markdownFilePath]]"></script>
                 </marked-element>
             </paper-dialog-scrollable>
         </paper-dialog>


### PR DESCRIPTION
1. move script tag outside of markdown-html slot
2. bind path to src attribute, not parameter ($ suffix)
3. use one way data binding