### PR TITLE
[#80] fix typo

### DIFF
--- a/markdown/en/core-result-dispatcher.md
+++ b/markdown/en/core-result-dispatcher.md
@@ -30,6 +30,7 @@ The function supplied in `fn` is invoked with data for the subscribed `topic` wh
 * `asn`
 * `singleWordSearch`
 * `productDetail`
+* `similarProducts`
 * `productCampaign` -special
 * `singleWordSearch`
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ff-documenation",
+  "name": "ff-documentation",
   "version": "1.0.0",
   "description": "FACT-Finder Web Components Documentation",
   "license": "UNLICENSED",

--- a/src/documentation-app.js
+++ b/src/documentation-app.js
@@ -29,7 +29,7 @@ setPassiveTouchGestures(true);
 // in `index.html`.
 setRootPath(MyAppGlobals.rootPath);
 
-class DocumenationApp extends ReduxMixin(PolymerElement) {
+class DocumentationApp extends ReduxMixin(PolymerElement) {
     static get template() {
         return html`<style include="shared-styles">
     :host {
@@ -181,6 +181,10 @@ class DocumenationApp extends ReduxMixin(PolymerElement) {
     `;
     }
 
+    static get is() {
+        return 'documentation-app';
+    }
+
     static get properties() {
         return {
             recordsText: {
@@ -217,4 +221,4 @@ class DocumenationApp extends ReduxMixin(PolymerElement) {
 
 }
 
-window.customElements.define('documentation-app', DocumenationApp);
+window.customElements.define(DocumentationApp.is, DocumentationApp);


### PR DESCRIPTION
fixes #80 
Typo fixed and class now uses `is()` getter in custom elements definition