### PR TITLE
[#76][FIX] click on same menu item bug

### DIFF
--- a/src/views/api-view.js
+++ b/src/views/api-view.js
@@ -206,12 +206,9 @@ class ApiView extends ViewMixin(ReduxMixin(PolymerElement)) {
             this.showTabs = false;
         }
 
-        if (!this.activeTab) {
-            this.activeTab = "docs";
-        }
     }
 
-    _tabChange(newTab) {
+    _tabChange(newTab, oldTab) {
         if (!this.isActiveView()) {
             return;
         }
@@ -230,6 +227,8 @@ class ApiView extends ViewMixin(ReduxMixin(PolymerElement)) {
         if (newTab) {
             const url = window.location.href.split('#')[0];
             window.location.replace(`${url}#tab=${newTab}`);
+        } else { //default tab
+            this.activeTab = "docs";
         }
     }
 }


### PR DESCRIPTION
fixes #76 

`activeTab` is defaulted to `docs` on initial page change, but becomes empty string when you click the same anchor again. this causes *no* tab to be selected => page looks cleared

solution:
move the default assignment to `activeTab`'s observer.