### PR TITLE
[FFWEB-805] add pages for ff-middleware and ff-multi-attribute-parsing

### DIFF
--- a/markdown/en/api/ff-middleware.api.md
+++ b/markdown/en/api/ff-middleware.api.md
@@ -1,0 +1,14 @@
+## `ff-middleware`
+___
+
+
+## `ff-multi-attribute-parsing`
+___
+### Properties
+| Name | Description |
+| ---- | ----------- |
+| **src-property**&nbsp;(String) (_required_)| The name of the multi-attribute field as returned by FACT-Finder |
+| **store-in-property**&nbsp;(String) (_required_)| The name of the property you want to store the parsed object in. This can be a new property or the same as `src-property` which would overwrite the old value. If it is another existing property, a warning will be emitted. Be aware that modules later in the middleware chain might rely on a certain data format. |
+| **keep-original-in-property**&nbsp;(String) (_optional_)| The name of the property you want to store the unparsed value in. This may be particularly useful when you overwrite the original property but still require the original value. |
+| **entry-separator**&nbsp;(String) (_optional_, default: "&#0448;")| The character configured in FACT-Finder delimiting key-value pairs.  |
+| **key-value-separator**&nbsp;(String) (_optional_, default: "=")| The character configured in FACT-Finder to separate keys from values. |

--- a/markdown/en/ff-middleware.md
+++ b/markdown/en/ff-middleware.md
@@ -1,0 +1,127 @@
+## Middleware
+
+Starting from version `1.2.12` FACT-Finder Web Components support the concept of middleware. You can register and configure pre-defined modules to manipulate the data being exchanged between Web Components and FACT-Finder.
+Middleware modules can be registered through custom elements or directly through JavaScript.
+
+## Custom Elements Approach
+
+To register middleware modules through custom elements place the `ff-middleware` element directly inside the `ff-communication` element. It is a container for all modules that shall be configured. 
+
+```html
+<ff-communication url="..."
+                  version="..."
+                  channel="...">
+    <ff-middleware></ff-middleware>
+</ff-communication>
+```
+
+Be sure to make `ff-middleware` an immediate child node of `ff-communication` like in the example or it will cause an error in the application. This is to ensure correct registration of modules.
+
+## JavaScript Approach
+
+In order to configure middleware using JavaScript you attach an event handler to the `ffReady` event. Modules are registered by calling `use()` of the desired middleware namespace.
+
+```javascript
+window.addEventListener("ffReady", () => {
+    factfinder.middleware.response.use(module);
+});
+```
+
+Inside the `factfinder.middleware` namespace you have the option to choose for which part of data exchange you want to register a middleware module. In this example it is `response`. That means after a request to FACT-Finder returns, but before it is sent to the Web Components on the page, the specified module is applied to the response manipulating it in the way configured.
+
+## Available Modules
+
+All modules can be registered through custom elements or through JavaScript. When using custom elements, as with `ff-middleware` and `ff-communication`, modules must be placed immediately inside the `ff-middelware` element or an error will occur. Again, this is to ensure correct registration with the application.
+
+There is currently one module available. More modules are expected to be added in future releases.
+
+### Response
+
+Modules in this namespace are aimed at manipulating response data. They are located in `factfinder.middleware.response` and are registered with `factfinder.middleware.response.use()`.
+
+#### MultiAttributeParsing
+
+This module is used to parse _multi-attribute fields_ and make their values more easily accessible. FACT-Finder returns multi-attribute fields as a string:
+
+```javascript
+"|Size=M|Material=Cotton|Material=Synthetic fibres|Weight~~g=80|Recommended use=Leisure"
+```
+
+In this format you cannot use individual values immediately. You need to parse this string and translate it to a more accessible format. `MultiAttributeParsing` will parse the multi-attribute string according to the specified configuration and generate a plain JavaScript object.
+
+```json
+{
+    "Size": [
+        { "value": "M", "unit": undefined }
+    ],
+    "Material": [
+        { "value": "Cotton", "unit": undefined },
+        { "value": "Synthetic fibres", "unit": undefined }
+    ],
+    "Weight": [
+        { "value": "80", "unit": "g" }
+    ],
+    "Recommended use": [
+        { "value": "Leisure", "unit": undefined }
+    ]
+}
+```
+
+To render the parsed data format you need the mustache syntax for non-empty lists. See their [documentation](https://github.com/janl/mustache.js#non-empty-lists) for further details.
+
+Assuming there is a multi-attribute field called `MultiFilter` and its value was replaced by the parsed object, usage could look like this:
+
+```html
+<ff-record-list>
+    <ff-record>
+        <img data-image={{record.ImageName}}
+             data-image-onerror="../img_not_found.gif">
+
+        <div>
+            <div>{{record.Title}}</span>
+            <div>Price: <strong>{{record.Price}}</strong></div>
+
+            <div>Recommended use:
+                {{#record.MultiFilter.Recommended use}}<span>{{value}}</span>{{/record.MultiFilter.Recommended use}}</div>
+            <div>Material:
+                {{#record.MultiFilter.Material}}<span>{{value}}</span>{{/record.MultiFilter.Material}}</div>
+            <div>Weight:
+                {{#record.MultiFilter.Weight}}<span>{{value}} {{unit}}</span>{{/record.MultiFilter.Properties}}</div>
+        </div>
+    </ff-record>
+</ff-record-list>
+```
+
+_Note that mustache allows spaces in names as seen in_ `Recommended use`.
+
+Registration of `MultiAttributeParsing` using Web Components is done as follows.
+
+Web Components:
+```html
+<ff-communication>
+    <ff-middleware>
+        <ff-multi-attribute-parsing
+                src-property="MultiFilter"
+                store-in-property="MultiFilter"
+                keep-original-in-property="OriginalMultiFilter"
+                entry-separator="|"
+                key-value-separator="="
+        ></ff-multi-attribute-parsing>
+    </ff-middleware>
+</ff-communication>
+```
+
+JavaScript:
+```javascript
+window.addEventListener("ffReady", () => {
+    factfinder.middleware.response.use(factfinder.middleware.response.MultiAttributeParsing({
+        srcProperty: "MultiFilter",
+        storeInProperty: "MultiFilter",
+        keepOriginalInProperty: "OriginalMultiFilter",
+        entrySeparator: "|",
+        keyValueSeparator: "="
+    }));
+);
+```
+
+See the [API tab](/api/ff-middleware#tab=api) for more details on configuration options.

--- a/markdown/en/ff-middleware.md
+++ b/markdown/en/ff-middleware.md
@@ -67,7 +67,7 @@ In this format you cannot use individual values immediately. You need to parse t
 }
 ```
 
-To render the parsed data format you need the mustache syntax for non-empty lists. See their [documentation](https://github.com/janl/mustache.js#non-empty-lists) for further details.
+To render the parsed data format you need the mustache syntax for non-empty lists. See the [mustache.js documentation](https://github.com/janl/mustache.js#non-empty-lists) for further details.
 
 Assuming there is a multi-attribute field called `MultiFilter` and its value was replaced by the parsed object, usage could look like this:
 

--- a/markdown/en/ff-middleware.md
+++ b/markdown/en/ff-middleware.md
@@ -1,11 +1,11 @@
 ## Middleware
 
 Starting from version `1.2.13` FACT-Finder Web Components support the concept of middleware. You can register and configure pre-defined modules to manipulate the data being exchanged between Web Components and FACT-Finder.
-Middleware modules can be registered through custom elements or directly through JavaScript.
+Middleware modules can be registered through Web Components themselves or directly through JavaScript.
 
-## Custom Elements Approach
+## Web Components Approach
 
-To register middleware modules through custom elements place the `ff-middleware` element directly inside the `ff-communication` element. It is a container for all modules that shall be configured. 
+To register middleware modules using Web Components place the `ff-middleware` element directly inside the `ff-communication` element. It is a container for all modules that shall be configured.
 
 ```html
 <ff-communication url="..."
@@ -31,7 +31,7 @@ Inside the `factfinder.middleware` namespace you have the option to choose for w
 
 ## Available Modules
 
-All modules can be registered through custom elements or through JavaScript. When using custom elements, as with `ff-middleware` and `ff-communication`, modules must be placed immediately inside the `ff-middelware` element or an error will occur. Again, this is to ensure correct registration with the application.
+All modules can be registered through Web Components or through JavaScript. When using Web Components, as with `ff-middleware` and `ff-communication`, modules must be placed immediately inside the `ff-middelware` element or an error will occur. Again, this is to ensure correct registration with the application.
 
 There is currently one module available. More modules are expected to be added in future releases.
 

--- a/markdown/en/ff-middleware.md
+++ b/markdown/en/ff-middleware.md
@@ -94,7 +94,7 @@ Assuming there is a multi-attribute field called `MultiFilter` and its value was
 
 _Note that mustache allows spaces in names as seen in_ `Recommended use`.
 
-Registration of `MultiAttributeParsing` using Web Components is done as follows.
+Registration of `MultiAttributeParsing` using either Web Components or JavaScript is done as follows.
 
 Web Components:
 ```html

--- a/markdown/en/ff-middleware.md
+++ b/markdown/en/ff-middleware.md
@@ -27,7 +27,7 @@ window.addEventListener("ffReady", () => {
 });
 ```
 
-Inside the `factfinder.middleware` namespace you have the option to choose for which part of data exchange you want to register a middleware module. In this example it is `response`. That means after a request to FACT-Finder returns, but before it is sent to the Web Components on the page, the specified module is applied to the response manipulating it in the way configured.
+Inside the `factfinder.middleware` namespace you have the option to choose for which part of data exchange you want to register a middleware module. In this example it is `response`. That means after a request to FACT-Finder returns, but before it is emitted by the [ResultDispatcher](api/core-result-dispatcher#tab=docs) to its listeners (including the Web Components on the page), the specified module is applied to the response manipulating it in the way configured.
 
 ## Available Modules
 

--- a/markdown/en/ff-middleware.md
+++ b/markdown/en/ff-middleware.md
@@ -1,6 +1,6 @@
 ## Middleware
 
-Starting from version `1.2.12` FACT-Finder Web Components support the concept of middleware. You can register and configure pre-defined modules to manipulate the data being exchanged between Web Components and FACT-Finder.
+Starting from version `1.2.13` FACT-Finder Web Components support the concept of middleware. You can register and configure pre-defined modules to manipulate the data being exchanged between Web Components and FACT-Finder.
 Middleware modules can be registered through custom elements or directly through JavaScript.
 
 ## Custom Elements Approach

--- a/src/data/api.js
+++ b/src/data/api.js
@@ -118,6 +118,10 @@ const api = {
             title: "Checkout Tracking",
             noDemo: true
         },
+        "ff-middleware": {
+            path: "ff-middleware",
+            title: "Middleware",
+        },
 
 
         // --- obsolete pages ---
@@ -182,6 +186,7 @@ api.moreFeatures = [
     api.pages["ff-carousel"],
     api.pages["ff-tag-cloud"],
     api.pages["ff-template"],
+    api.pages["ff-middleware"],
 ];
 
 export default api;

--- a/src/data/api.js
+++ b/src/data/api.js
@@ -121,6 +121,7 @@ const api = {
         "ff-middleware": {
             path: "ff-middleware",
             title: "Middleware",
+            noDemo: true
         },
 
 


### PR DESCRIPTION
Adds a page for `ff-middleware` and `ff-multi-attribute-parsing`

Doesn't have a demo. I'm wondering whether it would make sense at all to have one in this case.