### PR TITLE
Ffweb 860 js configuration of ff communication

### DIFF
--- a/markdown/en/api/ff-record-list.api.md
+++ b/markdown/en/api/ff-record-list.api.md
@@ -10,7 +10,7 @@ ___
 | **infinite-debounce-delay** (Number) (default:32) | Sets the delay for when the next page should be loaded after the bottom is reached. This prevents loading multiple pages at once because it triggers to fast. The number is in milliseconds. |
 | **infinite-scroll-margin** (Number) (default: 0) |  Sets the margin of the page loading trigger element. This value can be positive or negative and is in 'px'. Is only applied when infinite-scroll is `true` |
 | **is-recommendation** (Boolean) | Indicates if this record-list is placed inside a ff-recommendation element. This attribute is set automatically by the ff-recommendation element and used for tracking purposes. |
-| **stamp-always** (Boolean) | ff-record are always reused and in addition if the new record set doesn't differ by oldRecord.id === newRecord.id dom is not updated. Add this attribute to disable this behavior. Using this attribute on ff-record-list will ensure all stamped ff-record will have this attribute added |
+| **stamp-always** (Boolean) | ff-record are always reused and in addition if the new record set doesn't differ by oldRecord.id === newRecord.id DOM is not updated. Add this attribute to disable this behavior. Using this attribute on ff-record-list will ensure all stamped ff-record will have this attribute added |
 
 ### Methods
 | Name | Description |
@@ -31,7 +31,7 @@ ___
 | **is-recommendation** (Boolean)| Indicates if this record-list is placed inside a ff-recommendation element. This attribute is set automatically by the ff-recommendation element and used for tracking purposes.|
 | **add-cart-click** (Boolean)|  [Tracking Guide](/guides/tracking-guide) |
 | **add-checkout-click** (Boolean)|  [Tracking Guide](/guides/tracking-guide) |
-| **stamp-always** (Boolean) | ff-record are always reused and in addition if the new record set doesn't differ by oldRecord.id === newRecord.id dom is not updated. Add this attribute to disable this behavior. Using this attribute on ff-record-list will ensure all stamped ff-record will have this attribute added |
+| **stamp-always** (Boolean) | ff-record are always reused and in addition if the new record set doesn't differ by oldRecord.id === newRecord.id DOM is not updated. Add this attribute to disable this behavior. Using this attribute on ff-record-list will ensure all stamped ff-record will have this attribute added |
 
 ### Directives
 | Name | Description |

--- a/markdown/en/api/ff-searchbox.api.md
+++ b/markdown/en/api/ff-searchbox.api.md
@@ -31,7 +31,7 @@ ___
 | **url**&nbsp;(String) &nbsp;(default: empty) | Your FACT-Finder URL. Please note that the url has to contain the FACT-Finder context name like: http://web-components.fact-finder.de/FACT-Finder-7.2/ |
 | **version**&nbsp;(String)&nbsp;(default: empty) | Your FACT-Finder version. Only major and minor version like "7.2" |
 | **channel**&nbsp;(String)&nbsp;(default: empty) | Your channel name. Has to be the same as the channel name configured in the FACT-Finder backend. |
-| **search-immediate**&nbsp;(Boolean) | If this property is present, web components will start searching as soon as they are loaded. |
+| **search-immediate**&nbsp;(Boolean) | If this property is present, Web Components will start searching as soon as they are loaded. |
 | **use-url-parameter**&nbsp;(String) **Options**: &nbsp;"true", &nbsp;"false" (default: "true") | If set to true, URL parameters are used instead of HTTP parameters. |
 | **use-cache**&nbsp;(Boolean) **Options**: &nbsp;true, &nbsp;false (default: false)| This value determines, if the browser should cache previous search requests or not. Some browsers support this feature and therefore speed up the search for repeated requests. |
 | **default-query**&nbsp; (String) (default: '*') | Determines which search term should is used by default if no search term provided in as http parameter or in a search event object. |

--- a/markdown/en/documentation/configuration.md
+++ b/markdown/en/documentation/configuration.md
@@ -18,7 +18,7 @@ Specify the FACT-Finder version. E.g. `7.2` or  `7.3`.
 ---
 
 #### **channel** 
-Specify the channel name which is used for the search. You can check which channels are available at the FACT-Finder UI.
+Specify the name of the channel which is used for the search. You can find the available channels in the FACT-Finder UI.
 
 ---
 
@@ -45,11 +45,11 @@ We recommend placing the `ff-communication` element immediately after the `body`
 ```
 
 #### **search-immediate**
-The `search-immediate` attribute ensures, that a search is automatically triggered as soon as `ff-communication` was successfully attached to the DOM. The triggered search request uses the current URL parameters. If no parameters are present, it uses `*` as query (search for all products) in conjunction with the other settings. 
+The `search-immediate` attribute ensures, that a search is automatically triggered as soon as `ff-communication` was successfully attached to the DOM. The triggered search request uses the current URL parameters in conjunction with the settings provided by `ff-communication`-attributes. If no search query is provided through the url or an attribute `*` will be used as default (search for all products). 
 
 **NOTE**
 
-You don't want the `search-immediate` attribute to be present on your landing (home) page because this would trigger a search every time a user enters your shop. Usually you want to use it only on category pages and the search result page.
+You don't want the `search-immediate` attribute to be present on your landing (home) page because this would trigger a search every time a user enters your shop. Usually you only want to use it on category pages and the search result page.
 
 
 ## JavaScript Approach
@@ -70,6 +70,7 @@ document.addEventListener("ffReady", () => { // "ffReady"-event ensures global f
 ``` 
 
 **NOTE**
-To prevent our custom elements from missing a factfinder response, before they where loaded, dispatching of results to subscribers is cached and deferred until all custom elements have loaded. When all custom elements have loaded, `ff-communication` calls `factfinder.communication.ResultDispatcher.startDispatching()`. If `ff-communication` is not used, `factfinder.communication.ResultDispatcher.startDispatching()` has to be called manually in JavaScript.
+
+To prevent our custom elements from missing a factfinder response, before they are loaded, dispatching of results to subscribers is cached and deferred until all custom elements are ready to receive the response. As soon as custom elements have finished loading `ff-communication` calls `factfinder.communication.ResultDispatcher.startDispatching()`. If `ff-communication` is not used, `factfinder.communication.ResultDispatcher.startDispatching()` has to be called manually in JavaScript.
 
 Also we discourage the direct use of custom JavaScript configuration and strongly recommend to configure everything through our custom elements, you might take a closer look at [ff-core.d.ts](https://github.com/FACT-Finder-Web-Components/ff-web-components/blob/master/dist/ff-core.d.ts). Everything which can be configured through our documented custom elements can also be configured directly in JavaScript. 

--- a/markdown/en/documentation/configuration.md
+++ b/markdown/en/documentation/configuration.md
@@ -45,7 +45,7 @@ We recommend placing the `ff-communication` element immediately after the `body`
 ```
 
 #### **search-immediate**
-The `search-immediate` attribute ensures, that a search is automatically triggered as soon as `ff-communication` was successfully attached to the dom. The triggered search request uses the current URL parameters. If no parameters are present, it uses `*` as query (search for all products) in conjunction with the other settings. 
+The `search-immediate` attribute ensures, that a search is automatically triggered as soon as `ff-communication` was successfully attached to the DOM. The triggered search request uses the current URL parameters. If no parameters are present, it uses `*` as query (search for all products) in conjunction with the other settings. 
 
 **NOTE**
 

--- a/markdown/en/documentation/configuration.md
+++ b/markdown/en/documentation/configuration.md
@@ -1,8 +1,28 @@
 ## Configuration
 
 ---
-This chapter describes the minimum configuration necessary to search and retrieve results from FACT-Finder.
+This chapter describes the minimal configuration necessary to search and retrieve results from FACT-Finder. You can configure the communication via the custom element `ff-communication` or directly via JavaScript.
 
+### A minimal configuration consists of the following settings:
+
+#### **url**
+Specify the FACT-Finder endpoint. Please note the context name `/FACT-Finder-7.2`. It is not sufficient to provide the top-level domain like `http://web-components.fact-finder.de/` which will result in an error.
+
+**Note:** Make sure you are using the same protocol (http://, https://) for the `url` setting and webapp. Using `url="http://web-components.fact-finder.de/FACT-Finder-7.2"` on a page hosted via **HTTPS** will result in an error.
+
+---
+
+#### **version**
+Specify the FACT-Finder version. E.g. `7.2` or  `7.3`.
+
+---
+
+#### **channel** 
+Specify the channel name which is used for the search. You can check which channels are available at the FACT-Finder UI.
+
+---
+
+## Custom Elements Approach
 ```html
 <body>
     <ff-communication url="http://web-components.fact-finder.de/FACT-Finder-7.2"
@@ -18,39 +38,38 @@ This chapter describes the minimum configuration necessary to search and retriev
 
 [Read Why](documentation/ready-events)
 
-We recommend placing the `ff-communication` element immediately after the `body` tag to reduce the risk of accidental reordering.
-
-It is advisable to add a comment explaining this requirement. For example:
+We recommend placing the `ff-communication` element immediately after the `body` tag to reduce the risk of accidental reordering. Furthermore we advise to add a comment explaining this requirement. For example:
 ```html
 <!-- The ff-communication element sets up the FF Web Components and must not be moved!
      All other FF Web Components must be placed hereafter. -->
 ```
 
-### Attributes
-
----
-#### **url**
-Specify the FACT-Finder endpoint. Please note the context name `/FACT-Finder-7.2`. It is not sufficient to provide the top-level domain like `http://web-components.fact-finder.de/` which will result in an error.
-
-**Note:** Make sure you are using the same protocol (http://, https://) for the `url` attribute and webapp. 
-
-Using `<ff-communication url="http://web-components.fact-finder.de/FACT-Finder-7.2" ...>` on a page hosted via **HTTPS** will result in an error.
-
----
-
-#### **version**
-Specify the FACT-Finder version. E.g. 7.2, 7.3 and so forth.
-
----
-
-#### **channel** 
-Specify the channel name which is used for the search. You can check which channels are available at the FACT-Finder UI.
-
----
-
 #### **search-immediate**
-`search-immediate` ensures that a search is automatically triggered when web components are loaded successfully. The triggered search request uses the current URL parameters. If no parameters are present, it uses `*` as query (search for all products) in conjunction with the parameters provided by the `ff-communication` element. 
+The `search-immediate` attribute ensures, that a search is automatically triggered as soon as `ff-communication` was successfully attached to the dom. The triggered search request uses the current URL parameters. If no parameters are present, it uses `*` as query (search for all products) in conjunction with the other settings. 
 
 **NOTE**
 
 You don't want the `search-immediate` attribute to be present on your landing (home) page because this would trigger a search every time a user enters your shop. Usually you want to use it only on category pages and the search result page.
+
+
+## JavaScript Approach
+While `ff-communication` provides a declarative way to configure the communication, it is also possible to do so directly via JavaScript as followed:
+
+```js
+document.addEventListener("ffReady", () => { // "ffReady"-event ensures global factfinder object to exist
+    factfinder.communication.globalSearchParameter.url = "http://web-components.fact-finder.de/FACT-Finder-7.2";
+    factfinder.communication.globalSearchParameter.version = "7.2";
+    factfinder.communication.globalSearchParameter.channel = "bergfreunde-co-uk";
+    
+    /* after this minimal configuration, a search can be triggered manual e.g. through */
+    factfinder.communication.FFCommunicationEventAggregator.addFFEvent({
+         type: "search",
+         query: "*"
+    });
+});
+``` 
+
+**NOTE**
+To prevent our custom elements from missing a factfinder response, before they where loaded, dispatching of results to subscribers is cached and deferred until all custom elements have loaded. When all custom elements have loaded, `ff-communication` calls `factfinder.communication.ResultDispatcher.startDispatching()`. If `ff-communication` is not used, `factfinder.communication.ResultDispatcher.startDispatching()` has to be called manually in JavaScript.
+
+Also we discourage the direct use of custom JavaScript configuration and strongly recommend to configure everything through our custom elements, you might take a closer look at [ff-core.d.ts](https://github.com/FACT-Finder-Web-Components/ff-web-components/blob/master/dist/ff-core.d.ts). Everything which can be configured through our documented custom elements can also be configured directly in JavaScript. 

--- a/markdown/en/documentation/currency-guide.md
+++ b/markdown/en/documentation/currency-guide.md
@@ -1,7 +1,7 @@
 ## Currencies and Number Format
 
 ---
-This guide covers everything to add `Currency Symbols` and `Number Formatting` like `£49.99 or 49,99 €` across all web components and related parts.
+This guide covers everything to add `Currency Symbols` and `Number Formatting` like `£49.99 or 49,99 €` across all Web Components and related parts.
 
 ### (TLDR;)Complete Example Configuration
 
@@ -85,7 +85,7 @@ Most of the time `de-DE` and `en-GB` are covering everything needed.
 
 ---
 #### **currency-fields (String)**
-If you are importing multiple price fields like discount prices or something similar it's not sufficient to specify only the `currency-country-code` and the `currency-code`. In order to format additional price fields you have to tell web components which fields should be processed. You can do that by setting the `currency-fields` attribute accordingly.  
+If you are importing multiple price fields like discount prices or something similar it's not sufficient to specify only the `currency-country-code` and the `currency-code`. In order to format additional price fields you have to tell Web Components which fields should be processed. You can do that by setting the `currency-fields` attribute accordingly.  
 
 **Example Usage**
 `<ff-communication currency-fields="discountPrice">`

--- a/markdown/en/documentation/include-scripts.md
+++ b/markdown/en/documentation/include-scripts.md
@@ -46,7 +46,7 @@ You **NEVER** want to change the loading or script order. Even the `Polymer.dom`
 
 ---
 
-In browsers where web components are not natively supported you might encounter ugly flashing of unstyled content while the page is loading. To prevent this just annotate all elements that have a visual component and are shown immediately on page load with the `unresolved` attribute.
+In browsers where Web Components are not natively supported you might encounter ugly flashing of unstyled content while the page is loading. To prevent this just annotate all elements that have a visual component and are shown immediately on page load with the `unresolved` attribute.
 ```html
 <ff-record-list unresolved></ff-record-list>
 ```

--- a/markdown/en/documentation/styling-elements.md
+++ b/markdown/en/documentation/styling-elements.md
@@ -48,7 +48,7 @@ It is important, that the style element possesses the property &quot;is&quot; wi
 ## Prevent FOUC (Flash Of Unstyled Content)
 
 ---
-In browsers where web components are not natively supported you might encounter ugly flashing of unstyled content while the page is loading. To prevent this just annotate all elements that have a visual component and are shown immediately on page load with the `unresolved` attribute.
+In browsers where Web Components are not natively supported you might encounter ugly flashing of unstyled content while the page is loading. To prevent this just annotate all elements that have a visual component and are shown immediately on page load with the `unresolved` attribute.
 ```html
 <ff-record-list unresolved></ff-record-list>
 ```

--- a/markdown/en/documentation/tracking-guide.md
+++ b/markdown/en/documentation/tracking-guide.md
@@ -82,7 +82,7 @@ In case a user is not logged in just leave it empty. **Never use a FakeId or som
 ---
 The `ff-checkout-tracking` element will send a checkout tracking request for each `ff-checkout-tracking-item` in it's DOM. This element is ment to be generated on server side after the checkout happened. For each product bought, you have to add an own `ff-checkout-tracking-item` with the according record-id and count. E.g. in the example below 5 items of product 10321926 were bought. 
 
-The tracking requests will be sent immediately after the element is parsed or, if you generate it in the javascript code, when it's appeneded to the DOM. 
+The tracking requests will be sent immediately after the element is parsed or, if you generate it in the JavaScript code, when it's appeneded to the DOM. 
 ```html
 <ff-checkout-tracking>
    <ff-checkout-tracking-item record-id="10321926" count="5"></ff-checkout-tracking-item>

--- a/markdown/en/ff-header-navigation.md
+++ b/markdown/en/ff-header-navigation.md
@@ -43,7 +43,7 @@ The `hide-empty-groups` hides all 'group' (layer 2) elements which has no 'links
 ### fetch-initial
 
 With the `fetch-initial` you can decide when the navigation data should be
-loaded. Usually, the data is loaded as soon as the element is attached to the dom. But maybe you want to manually
+loaded. Usually, the data is loaded as soon as the element is attached to the DOM. But maybe you want to manually
 trigger the loading or you want to reload. In that case, set the `fetch-initial` to
 'false' and use the `fetch()` method.
 

--- a/markdown/en/ff-tag-cloud.md
+++ b/markdown/en/ff-tag-cloud.md
@@ -10,7 +10,7 @@ Basic usage:
 <ff-tag-cloud min-font-size="10" max-font-size="40" word-count="50" unit="px"></ff-tag-cloud>
 ```
 **NOTE:**
-Changes to any property of the element, except `disable-auto`, will trigger a tag cloud request to FACT-Finder followed by a dom update. The default action on a click of a tag cloud child element will trigger a FACT-Finder search for that word. You can prevent this behavior by setting the `ffPreventDefault` on the `entry-clicked` event.
+Changes to any property of the element, except `disable-auto`, will trigger a tag cloud request to FACT-Finder followed by a DOM update. The default action on a click of a tag cloud child element will trigger a FACT-Finder search for that word. You can prevent this behavior by setting the `ffPreventDefault` on the `entry-clicked` event.
 
 **Example snippet: Prevent default click event and redirect to different page:**
 

--- a/markdown/en/overview-styling-elements.md
+++ b/markdown/en/overview-styling-elements.md
@@ -49,7 +49,7 @@ To overwrite the default styles the following code can be used:
 It is important, that the style element possesses the property &quot;is&quot; with the value &quot;custom-style&quot;.
 
 ## Prevent FOUC (Flash Of Unstyled Content)
-In browsers where web components are not natively supported you might encounter ugly flash of unstyled content on page load. 
+In browsers where Web Components are not natively supported you might encounter ugly flash of unstyled content on page load. 
 To prevent this we added a __remove unresolved attribute behavior__ to all elements with an visual component (e.g. ff-record-list, ff-asn and so on).
 Just annotate all elements which are shown immediately on page load with the __\[unresolved\]__  attribute. 
 In Addition add the following CSS rule on top of the page before the appearance of your  custom elements:


### PR DESCRIPTION
I included `search-immediate` because it was already there. What do you think about removing it from the "3. Configuration" section and move it to "4. Your First Search". My reasoning is, that it is useful for first search and things like category pages, but it is to much information for minimal setup. Specially with the note in this section, that you don't always want to use it, it feels missplaced there to me.

If you agree, I would do that in another future ticket / branch. 