### PR TITLE
add mixin section to ff-header-navigation for nav-elements' anchors

### DIFF
--- a/markdown/3.0/en/api/ff-header-navigation.api.md
+++ b/markdown/3.0/en/api/ff-header-navigation.api.md
@@ -15,6 +15,11 @@ ___
 | ---- | ----------- |
 | **fetch()** | Triggers a new fetch of the navigation data. |
 
+### Mixins
+| Name | Description |
+| ---- | ----------- |
+| **--nav-element-a** | Is applied to the anchor element inside each of the navigation's elements. |
+
 ### Events
 | Name | Description |
 | ---- | ----------- |


### PR DESCRIPTION
Documentation of the latest bugfix in `ff-header-navigation`.
If `ff-header-navigation` gets migrated to LitElement before the `3.0` release, this change is not relevant.