### PR TITLE
FFWEB-839 & FFWEB-842 upgrading to v3

### DIFF
--- a/markdown/3.0/en/documentation/include-scripts.md
+++ b/markdown/3.0/en/documentation/include-scripts.md
@@ -2,14 +2,7 @@
 
 ---
 
-The FACT-Finder Web Components build contains three files:
-1. `elements.build_with_dependencies.html` 
-    * This file contains all HTML pieces needed to provide DOM pieces (if needed) and a reference to `elements.build.js`
-2. `elements.build.js`
-    * Contains all the JavaScript code to make FACT-Finder Web Components work
-3. `webcomponents-lite.min.js`
-    * Contains the required polyfill to have FACT-Finder Web Components technology working in older browsers which don't support the Web Components spec natively. This is **always** required for all versions <= 1.3 
-
+The following section shows a boilerplate for including FACT-Finder Web Components in your website. `custom-elements-es5-adapter.js` and `webcomponents-loader.js` will load the required Polyfills minimized to the needs of the calling browser. 
 
 **Boilerplate Code**
 ```html
@@ -17,30 +10,15 @@ The FACT-Finder Web Components build contains three files:
     <meta charset="UTF-8">
     <title>Page Title</title>
 
-    <!-- Never change the order of the boilerplate -->
-    <script>
-        var Polymer = Polymer || {};
-        Polymer.dom = 'shady';
-    </script>
-    <script src="../bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
-    <link rel="import" href="../bower_components/ff-web-components/dist/elements.build_with_dependencies.html">
-    <style>
-        [unresolved] {
-            opacity: 0;
-        }        
-    </style>
-    <!-- boilerplate end -->
+    <!-- Do not change the order of the scripts -->
+    <script src="../dist/vendor/custom-elements-es5-adapter.js"></script>
+    <script src="../dist/vendor/webcomponents-loader.js"></script>
+    <script defer src="../dist/bundle.js"></script>
+    
+    <!-- You are free to customize those styles to your needs -->
+    <link rel="stylesheet" type="text/css" href="default-styles.css" />
 </head>
 ```
-**NOTE**
-
-The `elements.build.js` file does not need to be referenced directly from within your `index.html` because it is loaded by the `elements.build_with_dependencies.html`. However, it has to be placed in the same directory as `elements.build_with_dependencies.html`!
-
-## Loading Order
-
----
-
-You **NEVER** want to change the loading or script order. Even the `Polymer.dom` script has to be executed before loading the `webcomponents-lite.min.js` file.
 
 ## Prevent Flash Of Unstyled Content (FOUC)
 

--- a/markdown/3.0/en/documentation/upgrade-guide.md
+++ b/markdown/3.0/en/documentation/upgrade-guide.md
@@ -1,5 +1,5 @@
 ## Upgrade from version 1.2.x to 3.0.0
-We strongly recommend to upgrade your system to use the latest version of FACT-Finder Web Components. While we will do critical bug fixes for older versions, new features are likely to be implemented only in newer versions. In addition the newer versions stick to newer technology decreasing your loading time and improving internal speed. We promise to make each upgrade progress as ease as possible.
+We strongly recommend upgrading your system to use the latest version of FACT-Finder Web Components. While we will do critical bug fixes for older versions, new features will likely only be implemented in newer versions. In addition, the newer versions utilize newer technology, decreasing your loading time and improving internal speed. We promise to make each upgrade go as smoothly as possible.
 
 In general you can keep track of our progress, changes and new features in the [release notes](https://github.com/FACT-Finder-Web-Components/ff-web-components/blob/master/CHANGELOG.md).
 

--- a/markdown/3.0/en/documentation/upgrade-guide.md
+++ b/markdown/3.0/en/documentation/upgrade-guide.md
@@ -3,12 +3,10 @@ We strongly recommend to upgrade your system to use the latest version of FACT-F
 
 In general you can keep track of our progress, changes and new features in the [release notes](https://github.com/FACT-Finder-Web-Components/ff-web-components/blob/master/CHANGELOG.md).
 
-There are only two major changes and some minor API changes to take care of when upgrading from version 1.2.x to version 3.0.0,
-which can be taken care of quickly and easily:
+There are only two major changes and some minor API changes to take care of when upgrading from version 1.2.x to version 3.0.0. In addition css mixins have been removed. You can use normal css selector instead. Further more `ffw-` is introduced as name prefix for FACT-Finder Web Components custom class names.
 
 ### 2 major changes
-- Aligning with the current trend FACT-Finder Web Components are now shipped as ES6 Module instead of HTML Imports.
-Hence you have to load `bundle.js` instead of the HTML import as follows:
+- Aligning with the current trend FACT-Finder Web Components are now shipped as ES6 Module instead of HTML Imports. Hence you have to load `bundle.js` instead of the HTML import as follows:
    
 ```html
    <!-- Before -->
@@ -157,4 +155,27 @@ ff-nav-element.ffw-nav-item:hover
 ```
 --nav-element-a
 ff-nav-element a
+```
+
+#### ff-products-per-page-dropdown
+```
+`--dropdown-item-container`
+.ffw-ppp-dropdown-container
+```
+
+### Rename of class names
+
+#### ff-products-per-page-dropdown
+```
+ff-ppp-drowdown-closed // old class name
+ffw-ppp-dropdown-closed // new classname
+
+ff-ppp-dropdown-container
+ffw-ppp-dropdown-container
+```
+
+#### ff-products-per-page-item
+```
+selected
+ffw-selected
 ```

--- a/markdown/3.0/en/documentation/upgrade-guide.md
+++ b/markdown/3.0/en/documentation/upgrade-guide.md
@@ -3,10 +3,10 @@ We strongly recommend upgrading your system to use the latest version of FACT-Fi
 
 In general you can keep track of our progress, changes and new features in the [release notes](https://github.com/FACT-Finder-Web-Components/ff-web-components/blob/master/CHANGELOG.md).
 
-There are only two major changes and some minor API changes to take care of when upgrading from version 1.2.x to version 3.0.0. In addition css mixins have been removed. You can use normal css selector instead. Further more `ffw-` is introduced as name prefix for FACT-Finder Web Components custom class names.
+There are only two major changes and some minor API changes to take care of when upgrading from version 1.2.x to version 3.0.0. In addition, CSS mixins have been removed. You can use normal CSS selector instead. Further more `ffw-` is introduced as the prefix for FACT-Finder Web Components custom class names.
 
 ### 2 major changes
-- Aligning with the current trend FACT-Finder Web Components are now shipped as ES6 Module instead of HTML Imports. Hence you have to load `bundle.js` instead of the HTML import as follows:
+- Aligning with the current trend FACT-Finder Web Components are now shipped as ES6 Module instead of HTML Imports. Which is why you have to load `bundle.js` instead of the previous HTML import.
    
 ```html
    <!-- Before -->
@@ -34,7 +34,7 @@ There are only two major changes and some minor API changes to take care of when
 ```
 
 - With [Polymer 3](https://www.polymer-project.org/3.0/docs/devguide/feature-overview) extending built-in HTML elements
-is not possible anymore. Hence you have to nest an `input` into `ff-searchbox` and a `button` into `ff-searchbutton`
+is not possible anymore. Instead you will have to put an `input` into `ff-searchbox` and a `button` into `ff-searchbutton`
 as followed:
 
 ```html
@@ -51,12 +51,12 @@ as followed:
     </ff-searchbutton>
 ```
 Note that native `input` properties like `placeholder` stay within the `input` tag, while enhancements like 
-`suggest-onfocus` move into `ff-searchbox`. If you had used css to style your search input and button don't forget to adjust your selectors accordingly.
+`suggest-onfocus` move into `ff-searchbox`. If you're using CSS to style your search input and button don't forget to adjust your selectors accordingly.
 
 
 ### Minor API changes to take care of
-Beside the two major changes the following list contains all breaking changes.
-If we have missed something, we would be happy if you [contact](contacts) us.
+The following list contains all remaining breaking changes.
+If we have missed something, we would be happy if you [contacted](contacts) us.
 
 - `ff-asn-group`
     - use `<div slot="groupCaption" ...>` instead of `<div data-container="groupCaption" ...>`

--- a/markdown/3.0/en/documentation/upgrade-guide.md
+++ b/markdown/3.0/en/documentation/upgrade-guide.md
@@ -95,3 +95,73 @@ If we have missed something, we would be happy if you [contact](contacts) us.
           window.addEventListener('DOMContentLoaded', resolve);
         }
         ```
+
+### Removal of CSS mixins
+
+CSS mixins have been removed. You can now directly apply CSS rules.
+
+#### ff-header-navigation
+```
+--wrapper  // previous CSS-mixin
+ff-header-navigation .ffw-header-nav  // now recommended CSS-selector
+
+--header
+ff-header-navigation .ffw-header
+
+--header-hover
+ff-header-navigation .ffw-header:hover
+
+--nav-item-seperator
+ff-header-navigation .ffw-nav-item-separator
+
+--container
+ff-header-navigation .ffw-body
+
+--container-top
+ff-header-navigation .ffw-body-top
+
+--container-middle
+ff-header-navigation .ffw-body-middle
+
+--container-left
+ff-header-navigation .ffw-body-left
+
+--container-center
+ff-header-navigation .ffw-body-center
+
+--container-right
+ff-header-navigation .ffw-body-right
+
+--container-bottom
+ff-header-navigation .ffw-body-bottom
+
+--nav-group
+ff-header-navigation .ffw-nav-group
+
+--nav-group-hover
+ff-header-navigation .ffw-nav-group:hover
+
+--nav-group-caption
+ff-nav-element.ffw-nav-group-caption
+
+--nav-group-caption-hover
+ff-nav-element.ffw-nav-group-caption:hover
+
+--nav-link
+ff-nav-element.ffw-nav-link
+
+--nav-link-hover
+ff-nav-element.ffw-nav-link:hover
+
+--nav-item
+ff-nav-element.ffw-nav-item
+
+--nav-item-hover
+ff-nav-element.ffw-nav-item:hover
+```
+
+#### ff-nav-element
+```
+--nav-element-a
+ff-nav-element a
+```

--- a/markdown/3.0/en/documentation/upgrade-guide.md
+++ b/markdown/3.0/en/documentation/upgrade-guide.md
@@ -11,10 +11,10 @@ which can be taken care of quickly and easily:
 
 ### 2 major changes
 - Aligning with the current trend FACT-Finder Web Components are now shipped as ES6 Module instead of HTML Imports.
-Hence you have to load `bundle.js` instead of the HTML import as followed:
+Hence you have to load `bundle.js` instead of the HTML import as follows:
    
 ```html
-   <!-- Beofore -->
+   <!-- Before -->
    <script>
        var Polymer = Polymer || {};
        Polymer.dom = 'shady';
@@ -43,7 +43,7 @@ is not possible anymore. Hence you have to nest an `input` into `ff-searchbox` a
 as followed:
 
 ```html
-    <!-- Beofore -->
+    <!-- Before -->
     <ff-searchbox ...></ff-searchbox>
     <ff-searchbutton ...></ff-searchbutton>
            
@@ -62,8 +62,8 @@ If you had used css to style your search input and button don't forget to adjust
 
 
 ### Minor API changes to take care of
-Beside the two major changes the following list contains all breaking changing.
-If we have missed something, we would be happy, if you [contact](contacts) us.
+Beside the two major changes the following list contains all breaking changes.
+If we have missed something, we would be happy if you [contact](contacts) us.
 
 - `ff-asn-group`
     - use `<div slot="groupCaption" ...>` instead of `<div data-container="groupCaption" ...>`
@@ -79,11 +79,11 @@ If we have missed something, we would be happy, if you [contact](contacts) us.
     - removed `getCurrentSlide` method, use `currentSlide` property directly instead
     - removed `getMaxSlides` method, use `maxSlides` property directly instead
 - [Polymer 3](https://www.polymer-project.org/3.0/docs/devguide/feature-overview) related breaking changes:
-    - Polymer shady DOM was removed, because it is not necessary anymore. In cases you used something like
+    - Polymer shady DOM was removed, because it is not necessary anymore. In case you used something like
     `Polymer.dom(HTMLElement).innerHTML = ...` you now have to use the native DOM API directly like
     `HTMLElement.innerHTML = ...`
     - Polymer 1 did remove `unresolved` attribute of `body`-tag automatically. Polymer 3 does not.
-    If you depend on the old behaviour you can retain it with the following code:
+    If you depend on the old behaviour, you can retain it with the following code:
         ```js
         function resolve() {
           document.body.removeAttribute('unresolved');

--- a/markdown/3.0/en/documentation/upgrade-guide.md
+++ b/markdown/3.0/en/documentation/upgrade-guide.md
@@ -70,9 +70,7 @@ If we have missed something, we would be happy if you [contact](contacts) us.
 - `ff-slider`
     - use `<div slot="slider1" id="slider1" ...></div>` instead of `<div data-slider="1" ...></div>`
     - use `<div slot="slider2" id="slider2" ...></div>` instead of `<div data-slider="2" ...></div>`
-- `ff-carousel`
-    - removed `getCurrentSlide` method, use `currentSlide` property directly instead
-    - removed `getMaxSlides` method, use `maxSlides` property directly instead
+- `ff-carousel` is removed from this library
 - [Polymer 3](https://www.polymer-project.org/3.0/docs/devguide/feature-overview) related breaking changes:
     - Polymer shady DOM was removed, because it is not necessary anymore. In case you used something like
     `Polymer.dom(HTMLElement).innerHTML = ...` you now have to use the native DOM API directly like

--- a/markdown/3.0/en/documentation/upgrade-guide.md
+++ b/markdown/3.0/en/documentation/upgrade-guide.md
@@ -1,0 +1,97 @@
+## Upgrade from version 1.2.x to 3.0.0
+We strongly recommend to upgrade your system to use the latest version of FACT-Finder Web Components.
+While we maintain older versions, new features are likely to be implemented only in newer versions.
+In addition the newer versions stick to newer technology decreasing your loading time and improving internal speed.
+We promise to make each upgrade progress as ease as possible.
+
+In general you can keep track of our progress, changes and new features in the [release notes](https://github.com/FACT-Finder-Web-Components/ff-web-components/blob/master/CHANGELOG.md).
+
+There are only two major changes and some minor API changes to take care of when upgrading from version 1.2.x to version 3.0.0,
+which can be taken care of quickly and easily:
+
+### 2 major changes
+- Aligning with the current trend FACT-Finder Web Components are now shipped as ES6 Module instead of HTML Imports.
+Hence you have to load `bundle.js` instead of the HTML import as followed:
+   
+```html
+   <!-- Beofore -->
+   <script>
+       var Polymer = Polymer || {};
+       Polymer.dom = 'shady';
+   </script>
+   <script src="../bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
+   <link rel="import" href="../bower_components/ff-web-components/dist/elements.build_with_dependencies.html">
+   <style>
+       [unresolved] {
+           opacity: 0;
+       }        
+   </style>
+     
+   <!-- In version 3 -->
+   <script src="../node_modules/ff-web-components/dist/vendor/custom-elements-es5-adapter.js"></script>
+   <script src="../node_modules/ff-web-components/dist/vendor/webcomponents-loader.js"></script>
+   <script defer src="../node_modules/ff-web-components/dist/bundle.js"></script>
+ <style>
+     [unresolved] {
+         opacity: 0;
+     }        
+ </style>
+```
+
+- With [Polymer 3](https://www.polymer-project.org/3.0/docs/devguide/feature-overview) extending built-in HTML elements
+is not possible anymore. Hence you have to nest an `input` into `ff-searchbox` and a `button` into `ff-searchbutton`
+as followed:
+
+```html
+    <!-- Beofore -->
+    <ff-searchbox ...></ff-searchbox>
+    <ff-searchbutton ...></ff-searchbutton>
+           
+    <!-- In version 3. -->
+    <ff-searchbox ...>
+        <input .../>
+    </ff-searchbox>
+    <ff-searchbutton>
+        <button ...></button>
+    </ff-searchbutton>
+```
+Note that native `input` properties like `placeholder` stay within the `input` tag, while enhancements like 
+`suggest-onfocus` move into `ff-searchbox`.
+
+If you had used css to style your search input and button don't forget to adjust your selectors accordingly.
+
+
+### Minor API changes to take care of
+Beside the two major changes the following list contains all breaking changing.
+If we have missed something, we would be happy, if you [contact](contacts) us.
+
+- `ff-asn-group`
+    - use `<div slot="groupCaption" ...>` instead of `<div data-container="groupCaption" ...>`
+- `ff-asn-group-element`
+    - use `<div slot="selected" ...>` instead of `<div data-selected ...>`
+    - use `<div slot="unselected" ...>` instead of `<div data-unselected ...>`
+- `ff-asn-group-slider`
+    - use `<div slot="groupCaption" ...>` instead of `<div data-container="groupCaption" ...>`
+- `ff-slider`
+    - use `<div slot="slider1" id="slider1" ...></div>` instead of `<div data-slider="1" ...></div>`
+    - use `<div slot="slider2" id="slider2" ...></div>` instead of `<div data-slider="2" ...></div>`
+- `ff-carousel`
+    - removed `getCurrentSlide` method, use `currentSlide` property directly instead
+    - removed `getMaxSlides` method, use `maxSlides` property directly instead
+- [Polymer 3](https://www.polymer-project.org/3.0/docs/devguide/feature-overview) related breaking changes:
+    - Polymer shady DOM was removed, because it is not necessary anymore. In cases you used something like
+    `Polymer.dom(HTMLElement).innerHTML = ...` you now have to use the native DOM API directly like
+    `HTMLElement.innerHTML = ...`
+    - Polymer 1 did remove `unresolved` attribute of `body`-tag automatically. Polymer 3 does not.
+    If you depend on the old behaviour you can retain it with the following code:
+        ```js
+        function resolve() {
+          document.body.removeAttribute('unresolved');
+        }
+        
+        if (document.readyState === 'interactive' || document.readyState === 'complete') {
+          resolve();
+        } else {
+          window.addEventListener('DOMContentLoaded', resolve);
+        }
+        ```

--- a/markdown/3.0/en/documentation/upgrade-guide.md
+++ b/markdown/3.0/en/documentation/upgrade-guide.md
@@ -1,8 +1,5 @@
 ## Upgrade from version 1.2.x to 3.0.0
-We strongly recommend to upgrade your system to use the latest version of FACT-Finder Web Components.
-While we maintain older versions, new features are likely to be implemented only in newer versions.
-In addition the newer versions stick to newer technology decreasing your loading time and improving internal speed.
-We promise to make each upgrade progress as ease as possible.
+We strongly recommend to upgrade your system to use the latest version of FACT-Finder Web Components. While we will do critical bug fixes for older versions, new features are likely to be implemented only in newer versions. In addition the newer versions stick to newer technology decreasing your loading time and improving internal speed. We promise to make each upgrade progress as ease as possible.
 
 In general you can keep track of our progress, changes and new features in the [release notes](https://github.com/FACT-Finder-Web-Components/ff-web-components/blob/master/CHANGELOG.md).
 
@@ -56,9 +53,7 @@ as followed:
     </ff-searchbutton>
 ```
 Note that native `input` properties like `placeholder` stay within the `input` tag, while enhancements like 
-`suggest-onfocus` move into `ff-searchbox`.
-
-If you had used css to style your search input and button don't forget to adjust your selectors accordingly.
+`suggest-onfocus` move into `ff-searchbox`. If you had used css to style your search input and button don't forget to adjust your selectors accordingly.
 
 
 ### Minor API changes to take care of

--- a/markdown/3.0/en/ff-suggest.md
+++ b/markdown/3.0/en/ff-suggest.md
@@ -21,7 +21,7 @@ search box.
 ```
 
 For more information on `ff-searchbox`, see
-[Searchbox Example](api/ff-searchbox#tab=doc)
+[Searchbox Example](api/ff-searchbox#tab=docs)
 
 ## The basics
 

--- a/src/data/3.0/guides.js
+++ b/src/data/3.0/guides.js
@@ -18,6 +18,10 @@ const guides = {
             path: "your-first-search",
             title: "4. Your First Search",
         },
+        "upgrade-guide": {
+            path: "upgrade-guide",
+            title: "5. Upgrade Guide 1.2.x to 3.0.0",
+        },
 
         "attribute-basics": {
             path: "attribute-basics",
@@ -72,6 +76,7 @@ guides.firstSteps = [
     guides.pages["include-scripts"],
     guides.pages["configuration"],
     guides.pages["your-first-search"],
+    guides.pages["upgrade-guide"],
 ];
 
 guides.basics = [

--- a/src/views/download-view.js
+++ b/src/views/download-view.js
@@ -126,16 +126,14 @@ class DownloadView extends PolymerElement {
             <div class="container">
                 <div class="row" style="text-align: left">
                     <h1>Download</h1>
-                    <p>
-                         <span style="line-height: 24px">
-                            Please select your desired version and modules from below. You can read more about each feature by clicking the info icon
-                             <iron-icon icon="my-icons:info-outline"></iron-icon>.
-                             <br> Regardless of your chosen modules you'll get the core module with the minimum amount of functionality to get started.
-                         </span>
+                    <p style="line-height: 24px">
+                        Please select your desired version and modules from below. You can read more about each module by clicking the info icon
+                        <iron-icon icon="my-icons:info-outline"></iron-icon> next to it. You can read about the changes and new features of a version in the 
+                        <a href="https://github.com/FACT-Finder-Web-Components/ff-web-components/blob/master/CHANGELOG.md">official changelog</a>.
                     </p>
-
-                    <!--If you are looking for the latest version please check out our
-                    <a href="https://github.com/FACT-Finder-Web-Components">Github repository</a>.-->
+                    <p style="line-height: 24px">
+                        Regardless of your chosen modules you'll get the core module with the minimum amount of functionality to get started.
+                    </p>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
I think, it is nice to only have one branch for release/3.0. The upgrade guide is surely not finished yet, but an initial idea of how it might look.

I also added a link to the changelog in the download section, so that the user can easily see the changes, before he downloads a new version.

2 Things I like to discuss shortly (for a future PR):
1. I noticed that the titles in the side navigation bar don't always match the title of the pages (e.g. _Including Scripts_ in the side bar and as page title _Boilerplate_. Is it a good practise to keep those the same?
2. Changing the boilerplate I noticed, that our previous bundle was called _elements.bundle.js_ and now it is called _bundle,js_. Any objections against keeping the old name?