### PR TITLE
Remove ff-carousel from 3.0

### DIFF
--- a/src/data/3.0/api.js
+++ b/src/data/3.0/api.js
@@ -99,10 +99,11 @@ const api = {
             path: "ff-single-word-search",
             title: "Single Word Search",
         },
-        "ff-carousel": {
-            path: "ff-carousel",
-            title: "Carousel",
-        },
+        // TODO removed for 3.0 release -- might get reintroduced afterwards
+        // "ff-carousel": {
+        //     path: "ff-carousel",
+        //     title: "Carousel",
+        // },
         "ff-tag-cloud": {
             path: "ff-tag-cloud",
             title: "Tag Cloud",
@@ -188,7 +189,8 @@ api.moreFeatures = [
     api.pages["ff-compare"],
     api.pages["ff-similar-products"],
     api.pages["ff-single-word-search"],
-    api.pages["ff-carousel"],
+    // TODO removed for 3.0 release -- might get reintroduced afterwards
+    // api.pages["ff-carousel"],
     api.pages["ff-tag-cloud"],
     api.pages["ff-template"],
     api.pages["ff-middleware"],

--- a/src/views/download-view.js
+++ b/src/views/download-view.js
@@ -294,10 +294,11 @@ class DownloadView extends PolymerElement {
                     apiName: "campaigns",
                     active: false
                 }, {
-                    label: "Carousel",
-                    apiName: "carousel",
-                    active: false
-                }, {
+                // TODO removed for 3.0 release -- might get reintroduced afterwards
+                //     label: "Carousel",
+                //     apiName: "carousel",
+                //     active: false
+                // }, {
                     label: "Compare",
                     apiName: "compare",
                     active: false


### PR DESCRIPTION
Usage is low and time to release is not enough for migration to LitElement.
If actual demand is there, we can reintroduce it some time in the future.