### PR TITLE
Revise links

### DIFF
--- a/markdown/1.2/en/ImageBindingBehavior.md
+++ b/markdown/1.2/en/ImageBindingBehavior.md
@@ -24,5 +24,5 @@ You can overwrite the default binding by providing a value for the `data-image` 
 <img width="100" height="100" data-image="http://your-custom-image-server/{{attributes.articleNr}}" />
 ```
 
-Check out the [API tab](/api/ImageBindingBehavior#tab=api) for further supported attributes on image binding elements.
+Check out the [API tab](/api/1.2/ImageBindingBehavior#tab=api) for further supported attributes on image binding elements.
 

--- a/markdown/1.2/en/api/ff-campaign-pushed-products.api.md
+++ b/markdown/1.2/en/api/ff-campaign-pushed-products.api.md
@@ -4,5 +4,5 @@ ___
 | Name | Description |
 | ---- | ----------- |
 | **name**&nbsp;(String) (default: empty) | Binds the campaign to a campaign name defined in the FACT-Finder backend. |
-| **is-product-campaign**&nbsp;(Boolean) | If this attribute is present, regardless of its value, the `ff-campaign-pushed-products` is only considered for product campaigns retrieved by [ff-campaign-shopping-cart](http://web-components.fact-finder.de/documentation/ff-campaign-shopping-cart) |
-| **is-shopping-cart-campaign**&nbsp;(Boolean) | If this attribute is present, regardless of its value, the `ff-campaign-pushed-products` is only considered for shopping cart campaigns retrieved by [ff-campaign-shopping-cart](http://web-components.fact-finder.de/documentation/ff-campaign-shopping-cart) |
+| **is-product-campaign**&nbsp;(Boolean) | If this attribute is present, regardless of its value, the `ff-campaign-pushed-products` is only considered for product campaigns retrieved by [ff-campaign-shopping-cart](/documentation/1.2/ff-campaign-shopping-cart) |
+| **is-shopping-cart-campaign**&nbsp;(Boolean) | If this attribute is present, regardless of its value, the `ff-campaign-pushed-products` is only considered for shopping cart campaigns retrieved by [ff-campaign-shopping-cart](/documentation/1.2/ff-campaign-shopping-cart) |

--- a/markdown/1.2/en/api/ff-campaign.api.md
+++ b/markdown/1.2/en/api/ff-campaign.api.md
@@ -36,8 +36,8 @@ ___
 | Name | Description |
 | ---- | ----------- |
 | **label**&nbsp;(String) (default: "") | Binds the element to a campaign label defined in the FACT-Finder backend. |
-| **is-product-campaign**&nbsp;(Boolean) | If this attribute is present, regardless of its value, the `ff-campaign-feedbacktext` is only considered for product campaigns retrieved by [ff-campaign-product](http://web-components.fact-finder.de/documentation/ff-campaign-product) |
-| **is-shopping-cart-campaign**&nbsp;(Boolean) | If this attribute is present, regardless of its value, the `ff-campaign-feedbacktext` is only considered for shopping cart campaigns retrieved by [ff-campaign-shopping-cart](http://web-components.fact-finder.de/documentation/ff-campaign-shopping-cart) |
+| **is-product-campaign**&nbsp;(Boolean) | If this attribute is present, regardless of its value, the `ff-campaign-feedbacktext` is only considered for product campaigns retrieved by [ff-campaign-product](/documentation/1.2/ff-campaign-product) |
+| **is-shopping-cart-campaign**&nbsp;(Boolean) | If this attribute is present, regardless of its value, the `ff-campaign-feedbacktext` is only considered for shopping cart campaigns retrieved by [ff-campaign-shopping-cart](/documentation/1.2/ff-campaign-shopping-cart) |
 
 ### Events
 | Name | Description |

--- a/markdown/1.2/en/api/ff-searchbox.api.md
+++ b/markdown/1.2/en/api/ff-searchbox.api.md
@@ -64,12 +64,12 @@ ___
 | **similar-records-url**&nbsp;(String) | Define a custom URL for the SimilarRecords.ff Service. Example: `similar-records-url="http://www.myproxy.de/services"` Omit the `SimilarRecords.ff` in the URL. |
 | **get-records-url**&nbsp;(String) | Define a custom URL for the records API Service. Example: `get-records-url="http://www.myproxy.de/services"` |
 | **ignore-page**&nbsp;(String) **Options**: &nbsp;"true", &nbsp;"false" (default: "false") | If you want to omit the page parameter on pagination requests just set this attribute to true. Normally you want to use this attribute in conjunction with the `ff-record-list` `lazy-load` functionality. |
-| **currency-code**&nbsp;(String) | [Currency Guide](/documentation/currency-guide) |
-| **currency-country-code**&nbsp;(String) | [Currency Guide](/documentation/currency-guide) |
-| **currency-fields**&nbsp;(String) | [Currency Guide](/documentation/currency-guide) |
-| **currency-min-digits**&nbsp;(String) | [Currency Guide](/documentation/currency-guide) |
-| **currency-max-digits**&nbsp;(String) | [Currency Guide](/documentation/currency-guide) |
-| **add-unit-to-filter-elements**&nbsp;(Boolean) `true` if present, else `false` | [Currency Guide](/documentation/currency-guide) |
+| **currency-code**&nbsp;(String) | [Currency Guide](/documentation/1.2/currency-guide) |
+| **currency-country-code**&nbsp;(String) | [Currency Guide](/documentation/1.2/currency-guide) |
+| **currency-fields**&nbsp;(String) | [Currency Guide](/documentation/1.2/currency-guide) |
+| **currency-min-digits**&nbsp;(String) | [Currency Guide](/documentation/1.2/currency-guide) |
+| **currency-max-digits**&nbsp;(String) | [Currency Guide](/documentation/1.2/currency-guide) |
+| **add-unit-to-filter-elements**&nbsp;(Boolean) `true` if present, else `false` | [Currency Guide](/documentation/1.2/currency-guide) |
 | **disable-single-hit-redirect**&nbsp;(String) **Options**: &nbsp;"true", &nbsp;"false" (default: "false") | Disables the automatic redirect to the product detail page if only one record is found |
 | **single-hit-redirect-base-path**&nbsp;(String) | Use this as an absolute base path if deeplinks are relative |
 | **sort-url-parameters-alphabetically**&nbsp;(String) **Options**: &nbsp;"true", &nbsp;"false" (default: "false") | Sorts all query parameters and their values alphabetically. _This can be used for SEO._ |

--- a/markdown/1.2/en/core-result-dispatcher.md
+++ b/markdown/1.2/en/core-result-dispatcher.md
@@ -8,7 +8,7 @@ The ResultDispatcher is in the module:
 
 If you want to trigger your own communication events checkout the
 documentation for
-[`FFCommunicationEventAggregator`](api/core-event-aggregator#tab=docs).
+[`FFCommunicationEventAggregator`](/api/1.2/core-event-aggregator#tab=docs).
 
 ## API
 Here are all functions you can use with the **ResultDispatcher** 

--- a/markdown/1.2/en/documentation/attribute-basics.md
+++ b/markdown/1.2/en/documentation/attribute-basics.md
@@ -32,11 +32,11 @@ Attributes of type `String` typically have several possible values defined. Only
 <ff-communication use-url-parameter="true"> <!-- evaluates to true -->
 ``` 
 
-See the API section of an element for an overview of possible values. For example [`ff-searchbox`](api/ff-searchbox#tab=api).
+See the API section of an element for an overview of possible values. For example [`ff-searchbox`](/api/1.2/ff-searchbox#tab=api).
 
 ## Object/Array
 
-`Object` attributes are somehow different from other attributes. As mentioned in [element basics](documentation/communication) all elements are data driven.
+`Object` attributes are somehow different from other attributes. As mentioned in [element basics](/documentation/1.2/communication) all elements are data driven.
 
 For example the `ff-record-list` has a `records` property of type `Array`. What you now could possibly do is something like this:
 

--- a/markdown/1.2/en/documentation/communication.md
+++ b/markdown/1.2/en/documentation/communication.md
@@ -10,7 +10,7 @@ action is executed. FACT-Finder Web Components are basically data driven. They e
 which is capable of understanding the FACT-Finder API invocations and to retrieve the data like
 FACT-Finder would retrieve it. See the following image:
 
-![Folie3.PNG](../../images/kommunikation/Folie3.PNG)
+![Folie3.PNG](/images/kommunikation/Folie3.PNG)
 
 ## Change the Communication Flow
 
@@ -23,7 +23,7 @@ You can configure FACT-Finder Web Components to communicate with your shop backe
 on `<ff-communication>` element.
     
 Please see the following image for an rough overview of communication:
-![Folie1.PNG](../../images/kommunikation/Folie1.PNG)
+![Folie1.PNG](/images/kommunikation/Folie1.PNG)
 
 ### Detailed Overview of Communication
 
@@ -32,7 +32,7 @@ The following image illustrates the 5 steps to enrich search response with lates
  Steps marked in __orange__ are meant to be performed by the shop.
  Steps in __blue__ are meant to be performed automatically by FACT-Finder Web Components.
 
-![Folie2.PNG](../../images/kommunikation/Folie2.PNG) 
+![Folie2.PNG](/images/kommunikation/Folie2.PNG) 
        
 #### 1. Ajax Request
 

--- a/markdown/1.2/en/documentation/configuration.md
+++ b/markdown/1.2/en/documentation/configuration.md
@@ -36,7 +36,7 @@ Specify the name of the channel which is used for the search. You can find the a
 
 **The** `ff-communication` **element must be the first FF Web Component in DOM order!**
 
-[Read Why](documentation/ready-events)
+[Read Why](/documentation/1.2/ready-events)
 
 We recommend placing the `ff-communication` element immediately after the `body` tag to reduce the risk of accidental reordering. Furthermore we advise to add a comment explaining this requirement. For example:
 ```html

--- a/markdown/1.2/en/documentation/field-roles.md
+++ b/markdown/1.2/en/documentation/field-roles.md
@@ -53,7 +53,7 @@ the `fieldRoles` property on client-side:
 
 **In other words:** You might have a field called `prix` that contains the
 product's price in your product database. During set-up you assign the
-role `price` to your field `prix` in the FACT-Finder-UI. In order to use the [Currency Attributes](https://web-components.fact-finder.de/documentation/currency-guide) on your product detail page, you have to map `price` to
+role `price` to your field `prix` in the FACT-Finder-UI. In order to use the [Currency Attributes](/documentation/1.2/currency-guide) on your product detail page, you have to map `price` to
 `prix` in the `factfinder.communication.fieldRoles` property in your
 front-end.
 

--- a/markdown/1.2/en/documentation/ready-events.md
+++ b/markdown/1.2/en/documentation/ready-events.md
@@ -10,7 +10,7 @@ This event is fired if our core library has loaded and is fully functional.
 
 **What does that mean?**
 
-All our elements are utilizing the same Core functions described in our [ff-core.d.ts](https://github.com/FACT-Finder-Web-Components/ff-web-components/blob/master/dist/ff-core.d.ts) file or in our [Core API](https://web-components.fact-finder.de/api/core-result-dispatcher) documentation.
+All our elements are utilizing the same Core functions described in our [ff-core.d.ts](https://github.com/FACT-Finder-Web-Components/ff-web-components/blob/master/dist/ff-core.d.ts) file or in our [Core API](/api/1.2/core-result-dispatcher) documentation.
 
 Sometimes you want or have to change the data before all our elements being notified. This is where `ffReady` callback kicks in.
 

--- a/markdown/1.2/en/documentation/styling-elements.md
+++ b/markdown/1.2/en/documentation/styling-elements.md
@@ -5,7 +5,7 @@ FACT-Finder Web Components can be styled via CSS like regular HTML. Some element
 
 You can find all mixins and custom properties in the documentation or the HTML files of the individual elements.
 
-Example for the internal HTML structure of the [`ff-paging-item`](api/ff-paging#tab=docs):
+Example for the internal HTML structure of the [`ff-paging-item`](/api/1.2/ff-paging#tab=docs):
 ```html
 <dom-module id="ff-paging-item">
     <style>
@@ -30,7 +30,7 @@ Example for the internal HTML structure of the [`ff-paging-item`](api/ff-paging#
 </dom-module>
 ```
 
-In order to style the `<div>` inside this element the [`---paging-item-cursor-mixin`](ff-paging#tab=api) was introduced. To overwrite the default styles the following code can be used:
+In order to style the `<div>` inside this element the [`---paging-item-cursor-mixin`](/api/1.2/ff-paging#tab=api) was introduced. To overwrite the default styles the following code can be used:
 ```html
 <style is="custom-style">
     ff-paging-item {

--- a/markdown/1.2/en/documentation/template-engine.md
+++ b/markdown/1.2/en/documentation/template-engine.md
@@ -43,5 +43,5 @@ All bindings are resolved by the underlying template engine [mustache.js](https:
 
 You could do an **if** by using [this](https://github.com/janl/mustache.js/#false-values-or-empty-lists) syntax. 
 If the data is not formatted correctly, use the 
-[ResultDispatcher](/api/core-result-dispatcher)
+[ResultDispatcher](/api/1.2/core-result-dispatcher)
  to modify it accordingly.

--- a/markdown/1.2/en/documentation/template-engine.md
+++ b/markdown/1.2/en/documentation/template-engine.md
@@ -10,7 +10,7 @@ Key__) and navigating to the **Network** tab. Filtering by **XHR** makes things 
 Now invoke the search, two xhr requests will appear. The second one is the one we are looking for. Click the request URL,
  a second window on the right will appear. Navigate to the **Preview** tab to see the data as a JSON tree.
  
-![dev_tools_json7.PNG](../../images/templateEngine/dev_tools_json7.PNG "slots")
+![dev_tools_json7.PNG](/images/templateEngine/dev_tools_json7.PNG "slots")
 
 Every element with an visual component is bound to one or more of these objects. For example the ff-record
 element is bound to an item in the records array.
@@ -23,7 +23,7 @@ FACT-Finder. In this specific example product data is stored in an record object
 this object are imported during the data feed process. You can configure which fields are returned in the
 FACT-Finder backend.
 
-![record_json.PNG](../../images/templateEngine/record_json.PNG "slots")
+![record_json.PNG](/images/templateEngine/record_json.PNG "slots")
 
 Take a look at the following data-binding example to see how to access the data.
 ```html

--- a/markdown/1.2/en/documentation/tracking-with-js.md
+++ b/markdown/1.2/en/documentation/tracking-with-js.md
@@ -39,11 +39,11 @@ You can retrieve the current FACT-Finder Web Components **sid** by calling this 
 
 
 #### id 
-The **id** parameter has to match the field value of the field configured as `trackingProductNumber ` [field role](https://web-components.fact-finder.de/documentation/field-roles).
+The **id** parameter has to match the field value of the field configured as `trackingProductNumber ` [field role](/documentation/1.2/field-roles).
 
 
 #### masterId
-The **masterId** parameter has to match the field value of the field configured as `masterArticleNumber` [field role](https://web-components.fact-finder.de/documentation/field-roles).
+The **masterId** parameter has to match the field value of the field configured as `masterArticleNumber` [field role](/documentation/1.2/field-roles).
 
 
 #### channel

--- a/markdown/1.2/en/documentation/your-first-search.md
+++ b/markdown/1.2/en/documentation/your-first-search.md
@@ -3,14 +3,14 @@
 ---
 We recommend using the [ff-record-list demo](https://github.com/FACT-Finder-Web-Components/demos/blob/master/ff-record-list/index.html) as a starting point. It is lightweight and therefore ideal to get familiar with FACT-Finder Web Components.
 
-If you want a **quick overview** about all possible features, please refer to [`ff-record-list`](api/ff-record-list#tab=docs) in the API documentation.
+If you want a **quick overview** about all possible features, please refer to [`ff-record-list`](/api/1.2/ff-record-list#tab=docs) in the API documentation.
 
 The following sections cover all necessary steps to adjust the demo to fit your setup.
 
 ### Change Configuration
 
 ---
-In case you skipped previous sections please read more about the configuration [here](documentation/configuration).
+In case you skipped previous sections please read more about the configuration [here](/documentation/1.2/configuration).
 
 First of all you want to change the `url`, `channel` and the `version` attributes. If you don't know the channel name or your FACT-Finder version, please refer to your FACT-Finder UI.
 
@@ -33,7 +33,7 @@ The data used to display product information is provided by the CSV file you spe
 
 **This product data is returned in a one-to-one manner.** This means that a field named `Price` in the CSV file will also appear as `Price` (case sensitive) in the `searchResult.records[index].record` property of the HTTP response's JSON.
 
-The same `record` object is also available in several FACT-Finder Web Components. You can insert its values into your custom HTML using the double curly braces syntax `{{record.Title}}`. Here is an example using the [`ff-record`](api/ff-record-list#tab=docs) element:
+The same `record` object is also available in several FACT-Finder Web Components. You can insert its values into your custom HTML using the double curly braces syntax `{{record.Title}}`. Here is an example using the [`ff-record`](/api/1.2/ff-record-list#tab=docs) element:
 
 ```html
 <ff-record>
@@ -43,4 +43,4 @@ The same `record` object is also available in several FACT-Finder Web Components
 </ff-record>
 ```
 
-See the [Template Engine documentation](documentation/template-engine) for more details on this topic.
+See the [Template Engine documentation](/documentation/1.2/template-engine) for more details on this topic.

--- a/markdown/1.2/en/ff-asn.md
+++ b/markdown/1.2/en/ff-asn.md
@@ -73,7 +73,7 @@ the `[data-control="1/2"]` attribute. The input elements automatically
 react on user input (enter key pressed) and start to filter. You can
 change the behavior of the controls by using the appropriate attributes
 as described in `ff-slider-control-section`'s
-[API documentation](api/ff-asn#tab=api)
+[API documentation](/api/1.2/ff-asn#tab=api)
 
 ```html
 <!--style slider groups-->

--- a/markdown/1.2/en/ff-campaign-landing-page.md
+++ b/markdown/1.2/en/ff-campaign-landing-page.md
@@ -5,4 +5,4 @@ With the `ff-campaign-landing-page` you can display product campaigns on a custo
 <ff-campaign-landing-page page-id="home"></ff-campaign-landing-page>
 ```
 
-The element triggers the campaign but doesn't display anything. Depending on the configured campaign, you need to add a `ff-campaign-feedbacktext` to display the feedback text and/or a `ff-campaign-pushed-products` to display pushed products. For more information, see: [Campaign](http://web-components.fact-finder.de/documentation/ff-campaign) and [Pushed Products](http://web-components.fact-finder.de/documentation/ff-campaign-pushed-products).
+The element triggers the campaign but doesn't display anything. Depending on the configured campaign, you need to add a `ff-campaign-feedbacktext` to display the feedback text and/or a `ff-campaign-pushed-products` to display pushed products. For more information, see: [Campaign](http://web-components.fact-finder.de/documentation/ff-campaign) and [Pushed Products](/documentation/1.2/ff-campaign-pushed-products).

--- a/markdown/1.2/en/ff-campaign-product.md
+++ b/markdown/1.2/en/ff-campaign-product.md
@@ -5,4 +5,4 @@ With the `ff-campaign-product` you can display product campaigns on the product 
 <ff-campaign-product record-id="12345"></ff-campaign-product>
 ```
 
-The element triggers the campaign but doesn't display anything. Depending on the configured campaign, you need to add a `ff-campaign-feedbacktext` with attribute `is-product-campaign` to display the feedback text and/or a `ff-campaign-pushed-products` with attribute `is-product-campaign` to display pushed products. For more information, see: [Campaign](http://web-components.fact-finder.de/documentation/ff-campaign) and [Pushed Products](http://web-components.fact-finder.de/documentation/ff-campaign-pushed-products).
+The element triggers the campaign but doesn't display anything. Depending on the configured campaign, you need to add a `ff-campaign-feedbacktext` with attribute `is-product-campaign` to display the feedback text and/or a `ff-campaign-pushed-products` with attribute `is-product-campaign` to display pushed products. For more information, see: [Campaign](http://web-components.fact-finder.de/documentation/ff-campaign) and [Pushed Products](/documentation/1.2/ff-campaign-pushed-products).

--- a/markdown/1.2/en/ff-campaign-pushed-products.md
+++ b/markdown/1.2/en/ff-campaign-pushed-products.md
@@ -1,5 +1,5 @@
 ## Adding a Pushed Products campaign
-Adding a Pushed Products campaign is as simple as adding the products to your search result page. Just add a valid `ff-record-list` to the `ff-campaign-pushed-products` element. For more information on how to customize the product visualization please refer to the [ff-record-list](http://web-components.fact-finder.de/documentation/ff-record-list).
+Adding a Pushed Products campaign is as simple as adding the products to your search result page. Just add a valid `ff-record-list` to the `ff-campaign-pushed-products` element. For more information on how to customize the product visualization please refer to the [ff-record-list](/documentation/1.2/ff-record-list).
 
 ```html
 <ff-campaign-pushed-products>

--- a/markdown/1.2/en/ff-campaign-shopping-cart.md
+++ b/markdown/1.2/en/ff-campaign-shopping-cart.md
@@ -1,5 +1,5 @@
 ## Display Shopping Cart Campaigns
-With the `ff-campaign-shopping-cart` you can retrieve shopping cart campaigns for a given set of record (product) ids. This element is meant to be used in conjunction with [`ff-campaign-pushed-products`](http://web-components.fact-finder.de/documentation/ff-campaign-pushed-products) and [`ff-campaign-feedbacktext`](http://web-components.fact-finder.de/documentation/ff-campaign-feedbacktext) and the `[is-shopping-cart-campaign]` attribute.
+With the `ff-campaign-shopping-cart` you can retrieve shopping cart campaigns for a given set of record (product) ids. This element is meant to be used in conjunction with [`ff-campaign-pushed-products`](http://web-components.fact-finder.de/documentation/ff-campaign-pushed-products) and [`ff-campaign-feedbacktext`](/documentation/1.2/ff-campaign-feedbacktext) and the `[is-shopping-cart-campaign]` attribute.
 
 ```html
 <ff-campaign-shopping-cart record-id="123456"></ff-campaign-shopping-cart>

--- a/markdown/1.2/en/ff-header-navigation.md
+++ b/markdown/1.2/en/ff-header-navigation.md
@@ -210,7 +210,7 @@ dynamic slot after each group.
 ### Container slots
 
 We have a basic "top-bottom-left-right" layout around the container for the actual groups.
-![navigation-slots.png](../../images/doku/navigation-slots.png "slots")
+![navigation-slots.png](/images/doku/navigation-slots.png "slots")
 
 You can now define HTML elements, which should be only visible when a first level is hovered over. Add an element
 with the `slot` attribute and set the value of the attribute with the following pattern:
@@ -252,7 +252,7 @@ You can also set custom content after each group. Just add an element with the g
 ```
 
 This will add the content under the group items of the 'Outdoor jackets' group.
-![navigation-group-slot.png](../../images/doku/navigation-group-slot.png "navigation group slot")
+![navigation-group-slot.png](/images/doku/navigation-group-slot.png "navigation group slot")
 
 ### mixins
 

--- a/markdown/1.2/en/ff-middleware.md
+++ b/markdown/1.2/en/ff-middleware.md
@@ -27,7 +27,7 @@ window.addEventListener("ffReady", () => {
 });
 ```
 
-Inside the `factfinder.middleware` namespace you have the option to choose for which part of data exchange you want to register a middleware module. In this example it is `response`. That means after a request to FACT-Finder returns, but before it is emitted by the [ResultDispatcher](api/core-result-dispatcher#tab=docs) to its listeners (including the FACT-Finder Web Components on the page), the specified module is applied to the response manipulating it in the way configured.
+Inside the `factfinder.middleware` namespace you have the option to choose for which part of data exchange you want to register a middleware module. In this example it is `response`. That means after a request to FACT-Finder returns, but before it is emitted by the [ResultDispatcher](/api/1.2/core-result-dispatcher#tab=docs) to its listeners (including the FACT-Finder Web Components on the page), the specified module is applied to the response manipulating it in the way configured.
 
 ## Available Modules
 
@@ -124,4 +124,4 @@ window.addEventListener("ffReady", () => {
 );
 ```
 
-See the [API tab](/api/ff-middleware#tab=api) for more details on configuration options.
+See the [API tab](/api/1.2/ff-middleware#tab=api) for more details on configuration options.

--- a/markdown/1.2/en/ff-recommendation.md
+++ b/markdown/1.2/en/ff-recommendation.md
@@ -3,7 +3,7 @@ With the `ff-recommendation` you can display a set of records, which are present
 on his or her search history and his or her last purchased products or product views. The recommendation service learns
 the shopping behavior for each user and creates a list record which can be displayed to him or her.
 
-**IMPORTANT** [fieldRoles](documentation/field-roles) have to be [defined](documentation/field-roles)
+**IMPORTANT** [fieldRoles](/documentation/1.2/field-roles) have to be [defined](/documentation/1.2/field-roles)
 first in order for `ff-recommendation` to work.
 
 Inside the `ff-recommendation` tag you should define a `ff-record-list` to display and style the recommended products.

--- a/markdown/1.2/en/ff-searchbox.md
+++ b/markdown/1.2/en/ff-searchbox.md
@@ -22,7 +22,7 @@ The following code-example shows the aforementioned configuration.
                   search-immediate>
 </ff-communication>
 ```
-For more information, see the [API reference](/api/ff-searchbox#tab=api).
+For more information, see the [API reference](/api/1.2/ff-searchbox#tab=api).
 
 ## Extending the input
 The `ff-searchbox` extends a normal `<input>`. Simply add the attribute
@@ -50,7 +50,7 @@ should be selected when the search box gets focus. *(default is false)*
 If you want a suggest functionality on your page you can set the
 `use-suggest` attribute to **true** *(default is true)*. You also need
 to implement the `ff-suggest` tag on your page. For more information
-take a look at the [Suggest Example](/api/ff-suggest). The suggest will
+take a look at the [Suggest Example](/api/1.2/ff-suggest). The suggest will
 only trigger when at least 2 characters are in the input field.
 ```html
 <input is="ff-searchbox" use-sugest="true"/>

--- a/markdown/1.2/en/ff-similar-products.md
+++ b/markdown/1.2/en/ff-similar-products.md
@@ -1,7 +1,7 @@
 ## Overview
 With the `ff-similar-products` element, you can display a record-list of products which are similar to another product.
 
-**IMPORTANT** [fieldRoles](documentation/field-roles) have to be [defined](documentation/field-roles)
+**IMPORTANT** [fieldRoles](/documentation/1.2/field-roles) have to be [defined](/documentation/1.2/field-roles)
 first in order for `ff-recommendation` to work.
 
 In this element, you should use a `ff-record-list` to let the `ff-similar-products` inject the records returned from the similar-products service.

--- a/markdown/1.2/en/ff-suggest.md
+++ b/markdown/1.2/en/ff-suggest.md
@@ -21,7 +21,7 @@ search box.
 ```
 
 For more information on `ff-searchbox`, see
-[Searchbox Example](api/ff-searchbox#tab=doc)
+[Searchbox Example](/api/1.2/ff-searchbox#tab=doc)
 
 ## The basics
 
@@ -49,7 +49,7 @@ are found for this type.
 
 In addition you need to add a `ff-suggest-item` element inside the
 container. All received suggestions of this `"suggestType"` are inserted
-at this position and will be an exact copy of this element. `ff-suggest-item` supports [image binding](api/ImageBindingBehavior#tab=docs).
+at this position and will be an exact copy of this element. `ff-suggest-item` supports [image binding](/api/1.2/ImageBindingBehavior#tab=docs).
 
 Repeat this process for all configured `"suggestTypes"`.
 
@@ -79,7 +79,7 @@ braces and typed "back" in the search box, the HTML source code would be
 shown as a plain text: `<span class="query">Back</span>packs`
 rather than the rendered: "**Back**packs".
 
-See [Template Engine](documentation/template-engine) for more details.
+See [Template Engine](/documentation/1.2/template-engine) for more details.
 
 ## Add Keyboard Support
 

--- a/markdown/1.2/en/info/asn.md
+++ b/markdown/1.2/en/info/asn.md
@@ -2,6 +2,6 @@ The ASN module may be used to allow customers to further adjust the results of a
 navigation request to correspond to their needs, by selecting corresponding filters. The ASN
 module allows you to specify which filter options will be available for customers to select.
 
-![asn-example.png](../../../images/elements/asn-example.png)
+![asn-example.png](/images/elements/asn-example.png)
 
 

--- a/markdown/1.2/en/info/campaigns.md
+++ b/markdown/1.2/en/info/campaigns.md
@@ -2,7 +2,7 @@
 The Campaign Manager module allows you to target the management of search results in order to improve the customer lead process or deliberately highlight products. Campaigns are activated according to specific criteria and are then returned accordingly in the search results.
  Campaign Manager supports the following options:
  
-![campaign.png](../../../images/elements/examples/campaigns.png)
+![campaign.png](/images/elements/examples/campaigns.png)
 
 ## Redirection
  The campaign returns a URL to which the request should be redirected when the campaign triggers1. This is particularly useful if you already have individual landing pages for specific categories or areas. Another area that is frequently handled using redirection campaigns comprises service-related searches, such as searches for terms and conditions or the site publisher information.

--- a/markdown/1.2/en/info/carousel.md
+++ b/markdown/1.2/en/info/carousel.md
@@ -2,4 +2,4 @@ The carousel is a often used widget to display more records in a small space.
  This is useful to highlight a certain set of Records together like the recommendations or similar products.
  You can auto rotate trough the records or navigate slide per slide trough all the records in the set.
  
-![carousel.png](../../../images/elements/examples/carousel.png)
+![carousel.png](/images/elements/examples/carousel.png)

--- a/markdown/1.2/en/info/compare.md
+++ b/markdown/1.2/en/info/compare.md
@@ -1,3 +1,3 @@
 With the *compare* element, you can display a set of records with additional information and styling on fields which are different.
 
-![compare.png](../../../images/elements/examples/compare.png)
+![compare.png](/images/elements/examples/compare.png)

--- a/markdown/1.2/en/info/focusSuggest.md
+++ b/markdown/1.2/en/info/focusSuggest.md
@@ -1,7 +1,7 @@
 The onfocus suggest is a suggest which triggers a suggest result when you hover the found search terms in the first result.
 
 ### first sub suggest
-![on-focus-suggest.png](../../../images/elements/examples/on-focus-suggest.png)
+![on-focus-suggest.png](/images/elements/examples/on-focus-suggest.png)
  
 ### second sub suggest
-![on-focus-suggest.png](../../../images/elements/examples/on-focus-suggest-2.png) 
+![on-focus-suggest.png](/images/elements/examples/on-focus-suggest-2.png) 

--- a/markdown/1.2/en/info/headerNavigation.md
+++ b/markdown/1.2/en/info/headerNavigation.md
@@ -1,4 +1,4 @@
 The header navigation is a widget for displaying a category tree as a dropdown toolbar menu with a hover 3 steps deep hierarchy.
   The first layer are the root categories. On hover on each root category all its sub-categories are grouped in a dropdown window.   
 
-![header-navigation.png](../../../images/elements/examples/header-navigation.png)
+![header-navigation.png](/images/elements/examples/header-navigation.png)

--- a/markdown/1.2/en/info/navigation.md
+++ b/markdown/1.2/en/info/navigation.md
@@ -2,7 +2,7 @@ The navigation is a tree like widget  which can be aligned horizontally or verti
 It will display the category structure of the given search result as a ...
 
 ### Horizontal Layout
-![navigation-horizontal.png](../../../images/elements/examples/navigation-horizontal.png)
+![navigation-horizontal.png](/images/elements/examples/navigation-horizontal.png)
 
 ### Vertical layout
-![navigation-vertical.png](../../../images/elements/examples/navigation-vertical.png)
+![navigation-vertical.png](/images/elements/examples/navigation-vertical.png)

--- a/markdown/1.2/en/info/paging.md
+++ b/markdown/1.2/en/info/paging.md
@@ -4,11 +4,11 @@ Pagination is one of the most basic features for a online shop.
  
 ## Page selection example 
 You can use this as a full page selection widget with flexible configuration options.  
-![paging.png](../../../images/elements/examples/paging.png)
+![paging.png](/images/elements/examples/paging.png)
 
-![paging-2.png](../../../images/elements/examples/paging-2.png)
+![paging-2.png](/images/elements/examples/paging-2.png)
 
 ## Page navigation example
 You can just use the 'next' and 'previous' functionality of the paging for a simple information widget.
 
-![paging-small.png](../../../images/elements/examples/paging-small.png)
+![paging-small.png](/images/elements/examples/paging-small.png)

--- a/markdown/1.2/en/info/productsPerPageDropdown.md
+++ b/markdown/1.2/en/info/productsPerPageDropdown.md
@@ -1,3 +1,3 @@
 With the products-per-page dropdown menu you can decide how many products should be visible on each page.
  
-![ppp.png](../../../images/elements/examples/ppp-dropdown.png)
+![ppp.png](/images/elements/examples/ppp-dropdown.png)

--- a/markdown/1.2/en/info/productsPerPageList.md
+++ b/markdown/1.2/en/info/productsPerPageList.md
@@ -1,3 +1,3 @@
 With the products-per-page list is you can decide how many products should be displaye for each search result page.
 
-![ppp-list.png](../../../images/elements/examples/ppp-list.PNG) 
+![ppp-list.png](/images/elements/examples/ppp-list.PNG) 

--- a/markdown/1.2/en/info/recommendation.md
+++ b/markdown/1.2/en/info/recommendation.md
@@ -2,4 +2,4 @@ You can achieve a sustainable increase in your shop's sales by using the techniq
 
 In order to determine this information, FACT-Finder analyses the purchases made in the shop and discovers which products and categories are related. You can then actively recommend these to other buyers interested in the same or similar items. The benefit to you is the ability to sell more products per purchase.
 
-![recommendation.png](../../../images/elements/examples/recommendation.png)
+![recommendation.png](/images/elements/examples/recommendation.png)

--- a/markdown/1.2/en/info/searchFeedback.md
+++ b/markdown/1.2/en/info/searchFeedback.md
@@ -1,7 +1,7 @@
 With the search-feedback you can offer customers the option to rate the search experience.
 
 ## As sidebar button (state 1)
-![feedback-1.png](../../../images/elements/examples/feedback-1.png)
+![feedback-1.png](/images/elements/examples/feedback-1.png)
 
 ## As question dialog (state 2)
-![feedback-2.png](../../../images/elements/examples/feedback-2.png)
+![feedback-2.png](/images/elements/examples/feedback-2.png)

--- a/markdown/1.2/en/info/similarProducts.md
+++ b/markdown/1.2/en/info/similarProducts.md
@@ -2,4 +2,4 @@ Similar Products returns a specific number of similar products for a given produ
 
 If the number of similar products in the database is smaller than desired only this smaller set is returned.
 
-![similar-products.png](../../../images/elements/examples/similar-products.png)
+![similar-products.png](/images/elements/examples/similar-products.png)

--- a/markdown/1.2/en/info/singleWordSearch.md
+++ b/markdown/1.2/en/info/singleWordSearch.md
@@ -1,4 +1,4 @@
 With the single-word-search element, you can split a search into separate words.
  Each word and its search results are rendered in a 'ff-single-word-search-record' element.
  
-![single-word-search.png](../../../images/elements/examples/single-word-search.png)
+![single-word-search.png](/images/elements/examples/single-word-search.png)

--- a/markdown/1.2/en/info/sort.md
+++ b/markdown/1.2/en/info/sort.md
@@ -1,3 +1,3 @@
 With the sort widget you can re-order the records according to the configuration in the FactFinder .
 
-![sort.png](../../../images/elements/examples/sort.png)
+![sort.png](/images/elements/examples/sort.png)

--- a/markdown/1.2/en/info/suggest.md
+++ b/markdown/1.2/en/info/suggest.md
@@ -6,4 +6,4 @@ Additional information can be displayed for users as well as the search suggesti
 
 The hits are normally taken from the search log files, which is why they may differ from the actual number of hits. Another disadvantage is that not all entries have hits, only those which have been searched for in the past. If the exact number of hits needs to be determined, this must be activated in the Management Interface. Note that doing this also impacts the performance of the Suggest import process significantly.
 
-![suggest.png](../../../images/elements/examples/suggest-2.png)
+![suggest.png](/images/elements/examples/suggest-2.png)

--- a/markdown/1.2/en/info/tagCloud.md
+++ b/markdown/1.2/en/info/tagCloud.md
@@ -1,3 +1,3 @@
 With the ff-tag-cloud, you can display the most searched words in your shop. The terms displayed in the Tag Cloud are provided by the Logfile Analysis which uses data provided by the Tracking API. Since this module is updated once per day by default, the terms appearing in the Tag Cloud will also be updated daily.
 
-![tag-cloud.png](../../../images/elements/examples/tag-cloud.png)
+![tag-cloud.png](/images/elements/examples/tag-cloud.png)

--- a/markdown/3.0/en/ImageBindingBehavior.md
+++ b/markdown/3.0/en/ImageBindingBehavior.md
@@ -24,5 +24,5 @@ You can overwrite the default binding by providing a value for the `data-image` 
 <img width="100" height="100" data-image="http://your-custom-image-server/{{attributes.articleNr}}" />
 ```
 
-Check out the [API tab](/api/ImageBindingBehavior#tab=api) for further supported attributes on image binding elements.
+Check out the [API tab](/api/3.0/ImageBindingBehavior#tab=api) for further supported attributes on image binding elements.
 

--- a/markdown/3.0/en/api/ff-campaign-pushed-products.api.md
+++ b/markdown/3.0/en/api/ff-campaign-pushed-products.api.md
@@ -4,5 +4,5 @@ ___
 | Name | Description |
 | ---- | ----------- |
 | **name**&nbsp;(String) (default: empty) | Binds the campaign to a campaign name defined in the FACT-Finder backend. |
-| **is-product-campaign**&nbsp;(Boolean) | If this attribute is present, regardless of its value, the `ff-campaign-pushed-products` is only considered for product campaigns retrieved by [ff-campaign-shopping-cart](http://web-components.fact-finder.de/documentation/ff-campaign-shopping-cart) |
-| **is-shopping-cart-campaign**&nbsp;(Boolean) | If this attribute is present, regardless of its value, the `ff-campaign-pushed-products` is only considered for shopping cart campaigns retrieved by [ff-campaign-shopping-cart](http://web-components.fact-finder.de/documentation/ff-campaign-shopping-cart) |
+| **is-product-campaign**&nbsp;(Boolean) | If this attribute is present, regardless of its value, the `ff-campaign-pushed-products` is only considered for product campaigns retrieved by [ff-campaign-shopping-cart](/documentation/3.0/ff-campaign-shopping-cart) |
+| **is-shopping-cart-campaign**&nbsp;(Boolean) | If this attribute is present, regardless of its value, the `ff-campaign-pushed-products` is only considered for shopping cart campaigns retrieved by [ff-campaign-shopping-cart](/documentation/3.0/ff-campaign-shopping-cart) |

--- a/markdown/3.0/en/api/ff-campaign.api.md
+++ b/markdown/3.0/en/api/ff-campaign.api.md
@@ -36,8 +36,8 @@ ___
 | Name | Description |
 | ---- | ----------- |
 | **label**&nbsp;(String) (default: "") | Binds the element to a campaign label defined in the FACT-Finder backend. |
-| **is-product-campaign**&nbsp;(Boolean) | If this attribute is present, regardless of its value, the `ff-campaign-feedbacktext` is only considered for product campaigns retrieved by [ff-campaign-product](http://web-components.fact-finder.de/documentation/ff-campaign-product) |
-| **is-shopping-cart-campaign**&nbsp;(Boolean) | If this attribute is present, regardless of its value, the `ff-campaign-feedbacktext` is only considered for shopping cart campaigns retrieved by [ff-campaign-shopping-cart](http://web-components.fact-finder.de/documentation/ff-campaign-shopping-cart) |
+| **is-product-campaign**&nbsp;(Boolean) | If this attribute is present, regardless of its value, the `ff-campaign-feedbacktext` is only considered for product campaigns retrieved by [ff-campaign-product](/documentation/3.0/ff-campaign-product) |
+| **is-shopping-cart-campaign**&nbsp;(Boolean) | If this attribute is present, regardless of its value, the `ff-campaign-feedbacktext` is only considered for shopping cart campaigns retrieved by [ff-campaign-shopping-cart](/documentation/3.0/ff-campaign-shopping-cart) |
 
 ### Events
 | Name | Description |

--- a/markdown/3.0/en/api/ff-searchbox.api.md
+++ b/markdown/3.0/en/api/ff-searchbox.api.md
@@ -68,12 +68,12 @@ ___
 | **similar-records-url**&nbsp;(String) | Define a custom URL for the SimilarRecords.ff Service. Example: `similar-records-url="http://www.myproxy.de/services"` Omit the `SimilarRecords.ff` in the URL. |
 | **get-records-url**&nbsp;(String) | Define a custom URL for the records API Service. Example: `get-records-url="http://www.myproxy.de/services"` |
 | **ignore-page**&nbsp;(String) **Options**: &nbsp;"true", &nbsp;"false" (default: "false") | If you want to omit the page parameter on pagination requests just set this attribute to true. Normally you want to use this attribute in conjunction with the `ff-record-list` `lazy-load` functionality. |
-| **currency-code**&nbsp;(String) | [Currency Guide](/documentation/currency-guide) |
-| **currency-country-code**&nbsp;(String) | [Currency Guide](/documentation/currency-guide) |
-| **currency-fields**&nbsp;(String) | [Currency Guide](/documentation/currency-guide) |
-| **currency-min-digits**&nbsp;(String) | [Currency Guide](/documentation/currency-guide) |
-| **currency-max-digits**&nbsp;(String) | [Currency Guide](/documentation/currency-guide) |
-| **add-unit-to-filter-elements**&nbsp;(Boolean) `true` if present, else `false` | [Currency Guide](/documentation/currency-guide) |
+| **currency-code**&nbsp;(String) | [Currency Guide](/documentation/3.0/currency-guide) |
+| **currency-country-code**&nbsp;(String) | [Currency Guide](/documentation/3.0/currency-guide) |
+| **currency-fields**&nbsp;(String) | [Currency Guide](/documentation/3.0/currency-guide) |
+| **currency-min-digits**&nbsp;(String) | [Currency Guide](/documentation/3.0/currency-guide) |
+| **currency-max-digits**&nbsp;(String) | [Currency Guide](/documentation/3.0/currency-guide) |
+| **add-unit-to-filter-elements**&nbsp;(Boolean) `true` if present, else `false` | [Currency Guide](/documentation/3.0/currency-guide) |
 | **disable-single-hit-redirect**&nbsp;(String) **Options**: &nbsp;"true", &nbsp;"false" (default: "false") | Disables the automatic redirect to the product detail page if only one record is found |
 | **single-hit-redirect-base-path**&nbsp;(String) | Use this as an absolute base path if deeplinks are relative |
 | **sort-url-parameters-alphabetically**&nbsp;(String) **Options**: &nbsp;"true", &nbsp;"false" (default: "false") | Sorts all query parameters and their values alphabetically. _This can be used for SEO._ |

--- a/markdown/3.0/en/core-result-dispatcher.md
+++ b/markdown/3.0/en/core-result-dispatcher.md
@@ -8,7 +8,7 @@ The ResultDispatcher is in the module:
 
 If you want to trigger your own communication events checkout the
 documentation for
-[`FFCommunicationEventAggregator`](api/core-event-aggregator#tab=docs).
+[`FFCommunicationEventAggregator`](/api/3.0/core-event-aggregator#tab=docs).
 
 ## API
 Here are all functions you can use with the **ResultDispatcher** 

--- a/markdown/3.0/en/documentation/attribute-basics.md
+++ b/markdown/3.0/en/documentation/attribute-basics.md
@@ -32,11 +32,11 @@ Attributes of type `String` typically have several possible values defined. Only
 <ff-communication use-url-parameter="true"> <!-- evaluates to true -->
 ``` 
 
-See the API section of an element for an overview of possible values. For example [`ff-searchbox`](api/ff-searchbox#tab=api).
+See the API section of an element for an overview of possible values. For example [`ff-searchbox`](/api/3.0/ff-searchbox#tab=api).
 
 ## Object/Array
 
-`Object` attributes are somehow different from other attributes. As mentioned in [element basics](documentation/communication) all elements are data driven.
+`Object` attributes are somehow different from other attributes. As mentioned in [element basics](/documentation/3.0/communication) all elements are data driven.
 
 For example the `ff-record-list` has a `records` property of type `Array`. What you now could possibly do is something like this:
 

--- a/markdown/3.0/en/documentation/communication.md
+++ b/markdown/3.0/en/documentation/communication.md
@@ -10,7 +10,7 @@ action is executed. FACT-Finder Web Components are basically data driven. They e
 which is capable of understanding the FACT-Finder API invocations and to retrieve the data like
 FACT-Finder would retrieve it. See the following image:
 
-![Folie3.PNG](../../images/kommunikation/Folie3.PNG)
+![Folie3.PNG](/images/kommunikation/Folie3.PNG)
 
 ## Change the Communication Flow
 
@@ -23,7 +23,7 @@ You can configure FACT-Finder Web Components to communicate with your shop backe
 on `<ff-communication>` element.
     
 Please see the following image for an rough overview of communication:
-![Folie1.PNG](../../images/kommunikation/Folie1.PNG)
+![Folie1.PNG](/images/kommunikation/Folie1.PNG)
 
 ### Detailed Overview of Communication
 
@@ -32,7 +32,7 @@ The following image illustrates the 5 steps to enrich search response with lates
  Steps marked in __orange__ are meant to be performed by the shop.
  Steps in __blue__ are meant to be performed automatically by FACT-Finder Web Components.
 
-![Folie2.PNG](../../images/kommunikation/Folie2.PNG) 
+![Folie2.PNG](/images/kommunikation/Folie2.PNG) 
        
 #### 1. Ajax Request
 

--- a/markdown/3.0/en/documentation/configuration.md
+++ b/markdown/3.0/en/documentation/configuration.md
@@ -36,7 +36,7 @@ Specify the name of the channel which is used for the search. You can find the a
 
 **The** `ff-communication` **element must be the first FF Web Component in DOM order!**
 
-[Read Why](documentation/ready-events)
+[Read Why](/documentation/3.0/ready-events)
 
 We recommend placing the `ff-communication` element immediately after the `body` tag to reduce the risk of accidental reordering. Furthermore we advise to add a comment explaining this requirement. For example:
 ```html

--- a/markdown/3.0/en/documentation/field-roles.md
+++ b/markdown/3.0/en/documentation/field-roles.md
@@ -53,7 +53,7 @@ the `fieldRoles` property on client-side:
 
 **In other words:** You might have a field called `prix` that contains the
 product's price in your product database. During set-up you assign the
-role `price` to your field `prix` in the FACT-Finder-UI. In order to use the [Currency Attributes](https://web-components.fact-finder.de/documentation/currency-guide) on your product detail page, you have to map `price` to
+role `price` to your field `prix` in the FACT-Finder-UI. In order to use the [Currency Attributes](/documentation/3.0/currency-guide) on your product detail page, you have to map `price` to
 `prix` in the `factfinder.communication.fieldRoles` property in your
 front-end.
 

--- a/markdown/3.0/en/documentation/ready-events.md
+++ b/markdown/3.0/en/documentation/ready-events.md
@@ -10,7 +10,7 @@ This event is fired if our core library has loaded and is fully functional.
 
 **What does that mean?**
 
-All our elements are utilizing the same Core functions described in our [ff-core.d.ts](https://github.com/FACT-Finder-Web-Components/ff-web-components/blob/master/dist/ff-core.d.ts) file or in our [Core API](https://web-components.fact-finder.de/api/core-result-dispatcher) documentation.
+All our elements are utilizing the same Core functions described in our [ff-core.d.ts](https://github.com/FACT-Finder-Web-Components/ff-web-components/blob/master/dist/ff-core.d.ts) file or in our [Core API](/api/3.0/core-result-dispatcher) documentation.
 
 Sometimes you want or have to change the data before all our elements being notified. This is where `ffReady` callback kicks in.
 

--- a/markdown/3.0/en/documentation/template-engine.md
+++ b/markdown/3.0/en/documentation/template-engine.md
@@ -43,5 +43,5 @@ All bindings are resolved by the underlying template engine [mustache.js](https:
 
 You could do an **if** by using [this](https://github.com/janl/mustache.js/#false-values-or-empty-lists) syntax. 
 If the data is not formatted correctly, use the 
-[ResultDispatcher](/api/core-result-dispatcher)
+[ResultDispatcher](/api/3.0/core-result-dispatcher)
  to modify it accordingly.

--- a/markdown/3.0/en/documentation/template-engine.md
+++ b/markdown/3.0/en/documentation/template-engine.md
@@ -10,7 +10,7 @@ Key__) and navigating to the **Network** tab. Filtering by **XHR** makes things 
 Now invoke the search, two xhr requests will appear. The second one is the one we are looking for. Click the request URL,
  a second window on the right will appear. Navigate to the **Preview** tab to see the data as a JSON tree.
  
-![dev_tools_json7.PNG](../../images/templateEngine/dev_tools_json7.PNG "slots")
+![dev_tools_json7.PNG](/images/templateEngine/dev_tools_json7.PNG "slots")
 
 Every element with an visual component is bound to one or more of these objects. For example the ff-record
 element is bound to an item in the records array.
@@ -23,7 +23,7 @@ FACT-Finder. In this specific example product data is stored in an record object
 this object are imported during the data feed process. You can configure which fields are returned in the
 FACT-Finder backend.
 
-![record_json.PNG](../../images/templateEngine/record_json.PNG "slots")
+![record_json.PNG](/images/templateEngine/record_json.PNG "slots")
 
 Take a look at the following data-binding example to see how to access the data.
 ```html

--- a/markdown/3.0/en/documentation/tracking-with-js.md
+++ b/markdown/3.0/en/documentation/tracking-with-js.md
@@ -39,11 +39,11 @@ You can retrieve the current FACT-Finder Web Components **sid** by calling this 
 
 
 #### id 
-The **id** parameter has to match the field value of the field configured as `trackingProductNumber ` [field role](https://web-components.fact-finder.de/documentation/field-roles).
+The **id** parameter has to match the field value of the field configured as `trackingProductNumber ` [field role](/documentation/3.0/field-roles).
 
 
 #### masterId
-The **masterId** parameter has to match the field value of the field configured as `masterArticleNumber` [field role](https://web-components.fact-finder.de/documentation/field-roles).
+The **masterId** parameter has to match the field value of the field configured as `masterArticleNumber` [field role](/documentation/3.0/field-roles).
 
 
 #### channel

--- a/markdown/3.0/en/documentation/your-first-search.md
+++ b/markdown/3.0/en/documentation/your-first-search.md
@@ -3,14 +3,14 @@
 ---
 We recommend using the [ff-record-list demo](https://github.com/FACT-Finder-Web-Components/demos/blob/master/ff-record-list/index.html) as a starting point. It is lightweight and therefore ideal to get familiar with FACT-Finder Web Components.
 
-If you want a **quick overview** about all possible features, please refer to [`ff-record-list`](api/ff-record-list#tab=docs) in the API documentation.
+If you want a **quick overview** about all possible features, please refer to [`ff-record-list`](/api/3.0/ff-record-list#tab=docs) in the API documentation.
 
 The following sections cover all necessary steps to adjust the demo to fit your setup.
 
 ### Change Configuration
 
 ---
-In case you skipped previous sections please read more about the configuration [here](documentation/configuration).
+In case you skipped previous sections please read more about the configuration [here](/documentation/3.0/configuration).
 
 First of all you want to change the `url`, `channel` and the `version` attributes. If you don't know the channel name or your FACT-Finder version, please refer to your FACT-Finder UI.
 
@@ -33,7 +33,7 @@ The data used to display product information is provided by the CSV file you spe
 
 **This product data is returned in a one-to-one manner.** This means that a field named `Price` in the CSV file will also appear as `Price` (case sensitive) in the `searchResult.records[index].record` property of the HTTP response's JSON.
 
-The same `record` object is also available in several FACT-Finder Web Components. You can insert its values into your custom HTML using the double curly braces syntax `{{record.Title}}`. Here is an example using the [`ff-record`](api/ff-record-list#tab=docs) element:
+The same `record` object is also available in several FACT-Finder Web Components. You can insert its values into your custom HTML using the double curly braces syntax `{{record.Title}}`. Here is an example using the [`ff-record`](/api/3.0/ff-record-list#tab=docs) element:
 
 ```html
 <ff-record>
@@ -43,4 +43,4 @@ The same `record` object is also available in several FACT-Finder Web Components
 </ff-record>
 ```
 
-See the [Template Engine documentation](documentation/template-engine) for more details on this topic.
+See the [Template Engine documentation](/documentation/3.0/template-engine) for more details on this topic.

--- a/markdown/3.0/en/ff-asn.md
+++ b/markdown/3.0/en/ff-asn.md
@@ -84,7 +84,7 @@ The `ff-asn-group-element` provides two **slots** to distinguish between selecte
 ```
 The position of the `ff-asn-group-element` inside the `ff-asn-group` does not matter. After initialization the element is removed from the DOM and saved for later usage.
 
-The `{{data-binding}}` for the `ff-asn-group-element` allows accessing both scopes - the `{{element}}` scope and the `{{group}}` scope. This is especially important if you want to display the unit which is configured on the server side. In addition, `ff-asn-group-element` does support [image binding](api/ImageBindingBehavior#tab=docs).
+The `{{data-binding}}` for the `ff-asn-group-element` allows accessing both scopes - the `{{element}}` scope and the `{{group}}` scope. This is especially important if you want to display the unit which is configured on the server side. In addition, `ff-asn-group-element` does support [image binding](/api/3.0/ImageBindingBehavior#tab=docs).
 
 
 ## Restricting filter group templates to filter-style
@@ -145,7 +145,7 @@ Slider groups a handled in a different way. To style them you need to use the `f
 
 A slider can have a `[slot="groupCaption"]` attribute but instead of detailedLinks and hiddenLinks the slider group accepts an `ff-slider-control` and/or an `ff-slider` element.
 
-The `ff-slider-control` can have two `input` elements annotated with the `[data-control="1/2"]` attribute. The input elements automatically react to user input (enter key pressed) and start to filter. You can change the behavior of the controls by using the appropriate attributes as described in `ff-slider-control-section`'s [API documentation](api/ff-asn#tab=api)
+The `ff-slider-control` can have two `input` elements annotated with the `[data-control="1/2"]` attribute. The input elements automatically react to user input (enter key pressed) and start to filter. You can change the behavior of the controls by using the appropriate attributes as described in `ff-slider-control-section`'s [API documentation](/api/3.0/ff-asn#tab=api)
 
 ```html
 <ff-asn-group-slider>

--- a/markdown/3.0/en/ff-campaign-landing-page.md
+++ b/markdown/3.0/en/ff-campaign-landing-page.md
@@ -5,4 +5,4 @@ With the `ff-campaign-landing-page` you can display product campaigns on a custo
 <ff-campaign-landing-page page-id="home"></ff-campaign-landing-page>
 ```
 
-The element triggers the campaign but doesn't display anything. Depending on the configured campaign, you need to add a `ff-campaign-feedbacktext` to display the feedback text and/or a `ff-campaign-pushed-products` to display pushed products. For more information, see: [Campaign](http://web-components.fact-finder.de/documentation/ff-campaign) and [Pushed Products](http://web-components.fact-finder.de/documentation/ff-campaign-pushed-products).
+The element triggers the campaign but doesn't display anything. Depending on the configured campaign, you need to add a `ff-campaign-feedbacktext` to display the feedback text and/or a `ff-campaign-pushed-products` to display pushed products. For more information, see: [Campaign](http://web-components.fact-finder.de/documentation/ff-campaign) and [Pushed Products](/documentation/3.0/ff-campaign-pushed-products).

--- a/markdown/3.0/en/ff-campaign-product.md
+++ b/markdown/3.0/en/ff-campaign-product.md
@@ -5,4 +5,4 @@ With the `ff-campaign-product` you can display product campaigns on the product 
 <ff-campaign-product record-id="12345"></ff-campaign-product>
 ```
 
-The element triggers the campaign but doesn't display anything. Depending on the configured campaign, you need to add a `ff-campaign-feedbacktext` with attribute `is-product-campaign` to display the feedback text and/or a `ff-campaign-pushed-products` with attribute `is-product-campaign` to display pushed products. For more information, see: [Campaign](http://web-components.fact-finder.de/documentation/ff-campaign) and [Pushed Products](http://web-components.fact-finder.de/documentation/ff-campaign-pushed-products).
+The element triggers the campaign but doesn't display anything. Depending on the configured campaign, you need to add a `ff-campaign-feedbacktext` with attribute `is-product-campaign` to display the feedback text and/or a `ff-campaign-pushed-products` with attribute `is-product-campaign` to display pushed products. For more information, see: [Campaign](http://web-components.fact-finder.de/documentation/ff-campaign) and [Pushed Products](/documentation/3.0/ff-campaign-pushed-products).

--- a/markdown/3.0/en/ff-campaign-pushed-products.md
+++ b/markdown/3.0/en/ff-campaign-pushed-products.md
@@ -1,5 +1,5 @@
 ## Adding a Pushed Products campaign
-Adding a Pushed Products campaign is as simple as adding the products to your search result page. Just add a valid `ff-record-list` to the `ff-campaign-pushed-products` element. For more information on how to customize the product visualization please refer to the [ff-record-list](http://web-components.fact-finder.de/documentation/ff-record-list).
+Adding a Pushed Products campaign is as simple as adding the products to your search result page. Just add a valid `ff-record-list` to the `ff-campaign-pushed-products` element. For more information on how to customize the product visualization please refer to the [ff-record-list](/documentation/3.0/ff-record-list).
 
 ```html
 <ff-campaign-pushed-products>

--- a/markdown/3.0/en/ff-campaign-shopping-cart.md
+++ b/markdown/3.0/en/ff-campaign-shopping-cart.md
@@ -1,5 +1,5 @@
 ## Display Shopping Cart Campaigns
-With the `ff-campaign-shopping-cart` you can retrieve shopping cart campaigns for a given set of record (product) ids. This element is meant to be used in conjunction with [`ff-campaign-pushed-products`](http://web-components.fact-finder.de/documentation/ff-campaign-pushed-products) and [`ff-campaign-feedbacktext`](http://web-components.fact-finder.de/documentation/ff-campaign-feedbacktext) and the `[is-shopping-cart-campaign]` attribute.
+With the `ff-campaign-shopping-cart` you can retrieve shopping cart campaigns for a given set of record (product) ids. This element is meant to be used in conjunction with [`ff-campaign-pushed-products`](http://web-components.fact-finder.de/documentation/ff-campaign-pushed-products) and [`ff-campaign-feedbacktext`](/documentation/3.0/ff-campaign-feedbacktext) and the `[is-shopping-cart-campaign]` attribute.
 
 ```html
 <ff-campaign-shopping-cart record-id="123456"></ff-campaign-shopping-cart>

--- a/markdown/3.0/en/ff-header-navigation.md
+++ b/markdown/3.0/en/ff-header-navigation.md
@@ -60,7 +60,7 @@ In some cases you may want custom content, like an Ad Banner or a group specific
 ### Container slots
 
 There are four container slots: `top`, `bottom`, `left` and `right`. These surround the actual groups.
-![navigation-slots.png](../../images/doku/navigation-slots.png "slots")
+![navigation-slots.png](/images/doku/navigation-slots.png "slots")
 
 You can now define HTML elements which shall only be visible when a specific first level item is hovered over. Add an element with the `slot` attribute and set the value of the attribute with the following pattern:
 
@@ -101,7 +101,7 @@ You can also insert custom content after each group. Just add an element with th
 ```
 
 This will add the content under the group items of the 'Outdoor jackets' group.
-![navigation-group-slot.png](../../images/doku/navigation-group-slot.png "navigation group slot")
+![navigation-group-slot.png](/images/doku/navigation-group-slot.png "navigation group slot")
 
 
 ## Rendered HTML

--- a/markdown/3.0/en/ff-middleware.md
+++ b/markdown/3.0/en/ff-middleware.md
@@ -124,4 +124,4 @@ window.addEventListener("ffReady", () => {
 );
 ```
 
-See the [API tab](/api/ff-middleware#tab=api) for more details on configuration options.
+See the [API tab](/api/3.0/ff-middleware#tab=api) for more details on configuration options.

--- a/markdown/3.0/en/ff-recommendation.md
+++ b/markdown/3.0/en/ff-recommendation.md
@@ -3,7 +3,7 @@ With the `ff-recommendation` you can display a set of records, which are present
 on his or her search history and his or her last purchased products or product views. The recommendation service learns
 the shopping behavior for each user and creates a list record which can be displayed to him or her.
 
-**IMPORTANT** [fieldRoles](documentation/field-roles) have to be [defined](documentation/field-roles)
+**IMPORTANT** [fieldRoles](/documentation/3.0/field-roles) have to be [defined](/documentation/3.0/field-roles)
 first in order for `ff-recommendation` to work.
 
 Inside the `ff-recommendation` tag you should define a `ff-record-list` to display and style the recommended products.

--- a/markdown/3.0/en/ff-searchbox.md
+++ b/markdown/3.0/en/ff-searchbox.md
@@ -22,7 +22,7 @@ The following code-example shows the aforementioned configuration.
                   search-immediate>
 </ff-communication>
 ```
-For more information, see the [API reference](/api/ff-searchbox#tab=api).
+For more information, see the [API reference](/api/3.0/ff-searchbox#tab=api).
 
 ## Wrapping input element with ff-searchbox
 The `ff-searchbox` wraps a regular HTML `<input>` element. Simply place
@@ -57,7 +57,7 @@ should be selected when the search box gets focus. *(default is `"false"`)*
 If you want a suggest functionality on your page you can set the
 `use-suggest` attribute to `"true"` *(default is `"true"`)*. You also need
 to implement the `ff-suggest` tag on your page. For more information
-take a look at the [Suggest Example](/api/ff-suggest). The suggest will
+take a look at the [Suggest Example](/api/3.0/ff-suggest). The suggest will
 only trigger when at least 2 characters are typed in the input field.
 ```html
 <ff-searchbox use-suggest="true">

--- a/markdown/3.0/en/ff-similar-products.md
+++ b/markdown/3.0/en/ff-similar-products.md
@@ -1,7 +1,7 @@
 ## Overview
 With the `ff-similar-products` element, you can display a record-list of products which are similar to another product.
 
-**IMPORTANT** [fieldRoles](documentation/field-roles) have to be [defined](documentation/field-roles)
+**IMPORTANT** [fieldRoles](/documentation/3.0/field-roles) have to be [defined](/documentation/3.0/field-roles)
 first in order for `ff-recommendation` to work.
 
 In this element, you should use a `ff-record-list` to let the `ff-similar-products` inject the records returned from the similar-products service.

--- a/markdown/3.0/en/ff-suggest.md
+++ b/markdown/3.0/en/ff-suggest.md
@@ -20,7 +20,7 @@ search box.
 ```
 
 For more information on `ff-searchbox`, see
-[Searchbox Example](api/ff-searchbox#tab=docs)
+[Searchbox Example](/api/3.0/ff-searchbox#tab=docs)
 
 ## The basics
 
@@ -48,7 +48,7 @@ are found for this type.
 
 In addition you need to add a `ff-suggest-item` element inside the
 container. All received suggestions of this `"suggestType"` are inserted
-at this position and will be an exact copy of this element. `ff-suggest-item` supports [image binding](api/ImageBindingBehavior#tab=docs).
+at this position and will be an exact copy of this element. `ff-suggest-item` supports [image binding](/api/3.0/ImageBindingBehavior#tab=docs).
 
 Repeat this process for all configured `"suggestTypes"`.
 
@@ -78,7 +78,7 @@ braces and typed "back" in the search box, the HTML source code would be
 shown as a plain text: `<span class="query">Back</span>packs`
 rather than the rendered: "**Back**packs".
 
-See [Template Engine](documentation/template-engine) for more details.
+See [Template Engine](/documentation/3.0/template-engine) for more details.
 
 ### Rendered HTML
 

--- a/markdown/3.0/en/info/asn.md
+++ b/markdown/3.0/en/info/asn.md
@@ -2,6 +2,6 @@ The ASN module may be used to allow customers to further adjust the results of a
 navigation request to correspond to their needs, by selecting corresponding filters. The ASN
 module allows you to specify which filter options will be available for customers to select.
 
-![asn-example.png](../../../images/elements/asn-example.png)
+![asn-example.png](/images/elements/asn-example.png)
 
 

--- a/markdown/3.0/en/info/campaigns.md
+++ b/markdown/3.0/en/info/campaigns.md
@@ -2,7 +2,7 @@
 The Campaign Manager module allows you to target the management of search results in order to improve the customer lead process or deliberately highlight products. Campaigns are activated according to specific criteria and are then returned accordingly in the search results.
  Campaign Manager supports the following options:
  
-![campaign.png](../../../images/elements/examples/campaigns.png)
+![campaign.png](/images/elements/examples/campaigns.png)
 
 ## Redirection
  The campaign returns a URL to which the request should be redirected when the campaign triggers1. This is particularly useful if you already have individual landing pages for specific categories or areas. Another area that is frequently handled using redirection campaigns comprises service-related searches, such as searches for terms and conditions or the site publisher information.

--- a/markdown/3.0/en/info/carousel.md
+++ b/markdown/3.0/en/info/carousel.md
@@ -2,4 +2,4 @@ The carousel is a often used widget to display more records in a small space.
  This is useful to highlight a certain set of Records together like the recommendations or similar products.
  You can auto rotate trough the records or navigate slide per slide trough all the records in the set.
  
-![carousel.png](../../../images/elements/examples/carousel.png)
+![carousel.png](/images/elements/examples/carousel.png)

--- a/markdown/3.0/en/info/compare.md
+++ b/markdown/3.0/en/info/compare.md
@@ -1,3 +1,3 @@
 With the *compare* element, you can display a set of records with additional information and styling on fields which are different.
 
-![compare.png](../../../images/elements/examples/compare.png)
+![compare.png](/images/elements/examples/compare.png)

--- a/markdown/3.0/en/info/focusSuggest.md
+++ b/markdown/3.0/en/info/focusSuggest.md
@@ -1,7 +1,7 @@
 The onfocus suggest is a suggest which triggers a suggest result when you hover the found search terms in the first result.
 
 ### first sub suggest
-![on-focus-suggest.png](../../../images/elements/examples/on-focus-suggest.png)
+![on-focus-suggest.png](/images/elements/examples/on-focus-suggest.png)
  
 ### second sub suggest
-![on-focus-suggest.png](../../../images/elements/examples/on-focus-suggest-2.png) 
+![on-focus-suggest.png](/images/elements/examples/on-focus-suggest-2.png) 

--- a/markdown/3.0/en/info/headerNavigation.md
+++ b/markdown/3.0/en/info/headerNavigation.md
@@ -1,4 +1,4 @@
 The header navigation is a widget for displaying a category tree as a dropdown toolbar menu with a hover 3 steps deep hierarchy.
   The first layer are the root categories. On hover on each root category all its sub-categories are grouped in a dropdown window.   
 
-![header-navigation.png](../../../images/elements/examples/header-navigation.png)
+![header-navigation.png](/images/elements/examples/header-navigation.png)

--- a/markdown/3.0/en/info/navigation.md
+++ b/markdown/3.0/en/info/navigation.md
@@ -2,7 +2,7 @@ The navigation is a tree like widget  which can be aligned horizontally or verti
 It will display the category structure of the given search result as a ...
 
 ### Horizontal Layout
-![navigation-horizontal.png](../../../images/elements/examples/navigation-horizontal.png)
+![navigation-horizontal.png](/images/elements/examples/navigation-horizontal.png)
 
 ### Vertical layout
-![navigation-vertical.png](../../../images/elements/examples/navigation-vertical.png)
+![navigation-vertical.png](/images/elements/examples/navigation-vertical.png)

--- a/markdown/3.0/en/info/paging.md
+++ b/markdown/3.0/en/info/paging.md
@@ -4,11 +4,11 @@ Pagination is one of the most basic features for a online shop.
  
 ## Page selection example 
 You can use this as a full page selection widget with flexible configuration options.  
-![paging.png](../../../images/elements/examples/paging.png)
+![paging.png](/images/elements/examples/paging.png)
 
-![paging-2.png](../../../images/elements/examples/paging-2.png)
+![paging-2.png](/images/elements/examples/paging-2.png)
 
 ## Page navigation example
 You can just use the 'next' and 'previous' functionality of the paging for a simple information widget.
 
-![paging-small.png](../../../images/elements/examples/paging-small.png)
+![paging-small.png](/images/elements/examples/paging-small.png)

--- a/markdown/3.0/en/info/productsPerPageDropdown.md
+++ b/markdown/3.0/en/info/productsPerPageDropdown.md
@@ -1,3 +1,3 @@
 With the products-per-page dropdown menu you can decide how many products should be visible on each page.
  
-![ppp.png](../../../images/elements/examples/ppp-dropdown.png)
+![ppp.png](/images/elements/examples/ppp-dropdown.png)

--- a/markdown/3.0/en/info/productsPerPageList.md
+++ b/markdown/3.0/en/info/productsPerPageList.md
@@ -1,3 +1,3 @@
 With the products-per-page list is you can decide how many products should be displaye for each search result page.
 
-![ppp-list.png](../../../images/elements/examples/ppp-list.PNG) 
+![ppp-list.png](/images/elements/examples/ppp-list.PNG) 

--- a/markdown/3.0/en/info/recommendation.md
+++ b/markdown/3.0/en/info/recommendation.md
@@ -2,4 +2,4 @@ You can achieve a sustainable increase in your shop's sales by using the techniq
 
 In order to determine this information, FACT-Finder analyses the purchases made in the shop and discovers which products and categories are related. You can then actively recommend these to other buyers interested in the same or similar items. The benefit to you is the ability to sell more products per purchase.
 
-![recommendation.png](../../../images/elements/examples/recommendation.png)
+![recommendation.png](/images/elements/examples/recommendation.png)

--- a/markdown/3.0/en/info/searchFeedback.md
+++ b/markdown/3.0/en/info/searchFeedback.md
@@ -1,7 +1,7 @@
 With the search-feedback you can offer customers the option to rate the search experience.
 
 ## As sidebar button (state 1)
-![feedback-1.png](../../../images/elements/examples/feedback-1.png)
+![feedback-1.png](/images/elements/examples/feedback-1.png)
 
 ## As question dialog (state 2)
-![feedback-2.png](../../../images/elements/examples/feedback-2.png)
+![feedback-2.png](/images/elements/examples/feedback-2.png)

--- a/markdown/3.0/en/info/similarProducts.md
+++ b/markdown/3.0/en/info/similarProducts.md
@@ -2,4 +2,4 @@ Similar Products returns a specific number of similar products for a given produ
 
 If the number of similar products in the database is smaller than desired only this smaller set is returned.
 
-![similar-products.png](../../../images/elements/examples/similar-products.png)
+![similar-products.png](/images/elements/examples/similar-products.png)

--- a/markdown/3.0/en/info/singleWordSearch.md
+++ b/markdown/3.0/en/info/singleWordSearch.md
@@ -1,4 +1,4 @@
 With the single-word-search element, you can split a search into separate words.
  Each word and its search results are rendered in a 'ff-single-word-search-record' element.
  
-![single-word-search.png](../../../images/elements/examples/single-word-search.png)
+![single-word-search.png](/images/elements/examples/single-word-search.png)

--- a/markdown/3.0/en/info/sort.md
+++ b/markdown/3.0/en/info/sort.md
@@ -1,3 +1,3 @@
 With the sort widget you can re-order the records according to the configuration in the FactFinder .
 
-![sort.png](../../../images/elements/examples/sort.png)
+![sort.png](/images/elements/examples/sort.png)

--- a/markdown/3.0/en/info/suggest.md
+++ b/markdown/3.0/en/info/suggest.md
@@ -6,4 +6,4 @@ Additional information can be displayed for users as well as the search suggesti
 
 The hits are normally taken from the search log files, which is why they may differ from the actual number of hits. Another disadvantage is that not all entries have hits, only those which have been searched for in the past. If the exact number of hits needs to be determined, this must be activated in the Management Interface. Note that doing this also impacts the performance of the Suggest import process significantly.
 
-![suggest.png](../../../images/elements/examples/suggest-2.png)
+![suggest.png](/images/elements/examples/suggest-2.png)

--- a/markdown/3.0/en/info/tagCloud.md
+++ b/markdown/3.0/en/info/tagCloud.md
@@ -1,3 +1,3 @@
 With the ff-tag-cloud, you can display the most searched words in your shop. The terms displayed in the Tag Cloud are provided by the Logfile Analysis which uses data provided by the Tracking API. Since this module is updated once per day by default, the terms appearing in the Tag Cloud will also be updated daily.
 
-![tag-cloud.png](../../../images/elements/examples/tag-cloud.png)
+![tag-cloud.png](/images/elements/examples/tag-cloud.png)

--- a/src/documentation-app.js
+++ b/src/documentation-app.js
@@ -148,10 +148,10 @@ class DocumentationApp extends ReduxMixin(PolymerElement) {
                         <a name="home" href="[[rootPath]]home">Home</a>
                     </paper-tab>
                     <paper-tab name="api">
-                        <a name="api" href="[[rootPath]]api/[[latestVersion]]/ff-searchbox">API</a>
+                        <a name="api" href="[[rootPath]]api/[[version]]/ff-searchbox">API</a>
                     </paper-tab>
                     <paper-tab name="documentation">
-                        <a name="documentation" href="[[rootPath]]documentation/[[latestVersion]]/install-dist">Documentation</a>
+                        <a name="documentation" href="[[rootPath]]documentation/[[version]]/install-dist">Documentation</a>
                     </paper-tab>
                     <paper-tab name="download">
                         <a name="download" href="[[rootPath]]download">Download</a>
@@ -202,7 +202,11 @@ class DocumentationApp extends ReduxMixin(PolymerElement) {
                 type: String,
                 reflectToAttribute: true,
                 statePath: 'app.page'
-            }
+            },
+            version: {
+                type: String,
+                statePath: 'app.version',
+            },
         };
     }
 
@@ -217,7 +221,6 @@ class DocumentationApp extends ReduxMixin(PolymerElement) {
         super.ready();
         installRouter((location) => this.dispatch(navigate(window.decodeURIComponent(location.pathname), location.hash)));
         this.downloadToolUrl = config.downloadToolUrl;
-        this.latestVersion = config.versions[0].name;
     }
 
 }

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -2,14 +2,20 @@ import {
     UPDATE_PAGE,
     UPDATE_DRAWER_STATE
 } from '../actions/app.js';
+import config from "../../config";
 
-const app = (state = {drawerOpened: false}, action) => {
+const initialState = {
+    drawerOpened: false,
+    version: config.versions[0].name,
+};
+
+const app = (state = initialState, action) => {
     switch (action.type) {
         case UPDATE_PAGE:
             return {
                 ...state,
                 page: action.page,
-                version: action.version,
+                version: isValidVersion(action.version) ? action.version : state.version,
                 subpage: action.subpage,
                 tab: action.tab || "docs"
             };
@@ -24,3 +30,8 @@ const app = (state = {drawerOpened: false}, action) => {
 };
 
 export default app;
+
+const versionNames = config.versions.map(v => v.name);
+function isValidVersion(version) {
+    return versionNames.some(n => n === version);
+}

--- a/src/views/api-view.js
+++ b/src/views/api-view.js
@@ -73,8 +73,8 @@ class ApiView extends ViewMixin(ReduxMixin(PolymerElement)) {
 
 <app-drawer-layout narrow="{{narrow}}">
     <app-drawer id="drawer" slot="drawer" swipe-open="[[narrow]]" opened="{{drawerOpened}}">
+        <version-dropdown></version-dropdown>
         <div class="panel-menus">
-            <version-dropdown></version-dropdown>
             <iron-selector id="pageSelector"
                            selected="[[subpage]]"
                            attr-for-selected="name"

--- a/src/views/documentation-view.js
+++ b/src/views/documentation-view.js
@@ -42,8 +42,8 @@ class DocumentationView extends ViewMixin(ReduxMixin(PolymerElement)) {
 
 <app-drawer-layout narrow="{{narrow}}">
     <app-drawer id="drawer" slot="drawer" swipe-open="[[narrow]]" opened="{{drawerOpened}}">
+        <version-dropdown></version-dropdown>
         <div class="panel-menus">
-            <version-dropdown></version-dropdown>
             <iron-selector selected="[[subpage]]"
                            attr-for-selected="name"
                            class="drawer-list"


### PR DESCRIPTION
- "pin" version-dropdown at top so that the user can always see which version he is reading and always has to read the warning if he uses an old version
- keep version when navigating API and Documentation tab
- adjust all internal links to 1.2 / 3.0 structure