### PR TITLE
add ff-product-teaser-campaign-processor to ff-middleware

### DIFF
--- a/markdown/1.x/en/api/ff-middleware.api.md
+++ b/markdown/1.x/en/api/ff-middleware.api.md
@@ -12,3 +12,8 @@ ___
 | **keep-original-in-property**&nbsp;(String) (_optional_)| The name of the property you want to store the unparsed value in. This may be particularly useful when you overwrite the original property but still require the original value. |
 | **entry-separator**&nbsp;(String) (_optional_, default: "&#0448;")| The character configured in FACT-Finder delimiting key-value pairs.  |
 | **key-value-separator**&nbsp;(String) (_optional_, default: "=")| The character configured in FACT-Finder to separate keys from values. |
+
+## `ff-product-teaser-campaign-processor`
+---
+### Properties
+None.

--- a/markdown/1.x/en/ff-middleware.md
+++ b/markdown/1.x/en/ff-middleware.md
@@ -125,3 +125,27 @@ window.addEventListener("ffReady", () => {
 ```
 
 See the [API tab](/api/1.2/ff-middleware#tab=api) for more details on configuration options.
+
+#### ProductTeaserCampaignProcessor
+
+Starting with FACT-Finder version 7.3 and FACT-Finder Web Components version 1.2.16 _feedback text campaigns_ can be configured as _teaser_.
+
+Applying this module will insert all _teaser feedback text campaigns_ into `searchResult.records` at the configured positions. Hence, for each _teaser feedback text campaign_, a rendered `ff-record-list` will contain an `ff-record` element with an `is-teaser` attribute and its inner HTML set to the text specified in FACT-Finder.
+
+Configuration with FACT-Finder Web Components:
+```html
+<ff-communication>
+    <ff-middleware>
+        <ff-product-teaser-campaign-processor></ff-product-teaser-campaign-processor>
+    </ff-middleware>
+</ff-communication>
+```
+
+JavaScript:
+```javascript
+window.addEventListener("ffReady", () => {
+    factfinder.middleware.response.use(
+        factfinder.middleware.response.ProductTeaserCampaignProcessor()
+    );
+);
+```

--- a/markdown/1.x/en/ff-middleware.md
+++ b/markdown/1.x/en/ff-middleware.md
@@ -128,7 +128,7 @@ See the [API tab](/api/1.2/ff-middleware#tab=api) for more details on configurat
 
 #### ProductTeaserCampaignProcessor
 
-Starting with FACT-Finder version 7.3 and FACT-Finder Web Components version 1.2.16 _feedback text campaigns_ can be configured as _teaser_.
+Starting with FACT-Finder version 7.3.5-42 and FACT-Finder Web Components version 1.2.16 _feedback text campaigns_ can be configured as _teaser_.
 
 Applying this module will insert all _teaser feedback text campaigns_ into `searchResult.records` at the configured positions. Hence, for each _teaser feedback text campaign_, a rendered `ff-record-list` will contain an `ff-record` element with an `is-teaser` attribute and its inner HTML set to the text specified in FACT-Finder.
 

--- a/markdown/1.x/en/ff-product-teaser-campaign-processor.md
+++ b/markdown/1.x/en/ff-product-teaser-campaign-processor.md
@@ -1,6 +1,6 @@
 ## Overview
 
-Starting with FACT-Finder version 7.3 and FACT-Finder Web Components version 1.2.16 _feedback text campaigns_ can be configured as _teaser_. For enabling this behavior in FACT-Finder Web Components you only have to include the `ff-product-teaser-campaign-processor` middleware into your `ff-communication` element as follows:
+Starting with FACT-Finder version 7.3.5-42 and FACT-Finder Web Components version 1.2.16 _feedback text campaigns_ can be configured as _teaser_. For enabling this behavior in FACT-Finder Web Components you only have to include the `ff-product-teaser-campaign-processor` middleware into your `ff-communication` element as follows:
 
 ```html
 <ff-communication>

--- a/markdown/3.x/en/api/ff-middleware.api.md
+++ b/markdown/3.x/en/api/ff-middleware.api.md
@@ -12,3 +12,8 @@ ___
 | **keep-original-in-property**&nbsp;(String) (_optional_)| The name of the property you want to store the unparsed value in. This may be particularly useful when you overwrite the original property but still require the original value. |
 | **entry-separator**&nbsp;(String) (_optional_, default: "&#0448;")| The character configured in FACT-Finder delimiting key-value pairs.  |
 | **key-value-separator**&nbsp;(String) (_optional_, default: "=")| The character configured in FACT-Finder to separate keys from values. |
+
+## `ff-product-teaser-campaign-processor`
+---
+### Properties
+None.

--- a/markdown/3.x/en/ff-middleware.md
+++ b/markdown/3.x/en/ff-middleware.md
@@ -125,3 +125,25 @@ window.addEventListener("ffReady", () => {
 ```
 
 See the [API tab](/api/3.0/ff-middleware#tab=api) for more details on configuration options.
+
+#### ProductTeaserCampaignProcessor
+
+Applying this module will insert all _teaser feedback text campaigns_ into `searchResult.records` at the configured positions. Hence, for each _teaser feedback text campaign_, a rendered `ff-record-list` will contain an `ff-record` element with an `is-teaser` attribute and its inner HTML set to the text specified in FACT-Finder.
+
+Configuration with FACT-Finder Web Components:
+```html
+<ff-communication>
+    <ff-middleware>
+        <ff-product-teaser-campaign-processor></ff-product-teaser-campaign-processor>
+    </ff-middleware>
+</ff-communication>
+```
+
+JavaScript:
+```javascript
+window.addEventListener("ffReady", () => {
+    factfinder.middleware.response.use(
+        factfinder.middleware.response.ProductTeaserCampaignProcessor()
+    );
+);
+```

--- a/markdown/3.x/en/ff-product-teaser-campaign-processor.md
+++ b/markdown/3.x/en/ff-product-teaser-campaign-processor.md
@@ -1,6 +1,6 @@
 ## Overview
 
-Starting with FACT-Finder version 7.3 _feedback text campaigns_ can be configured as _teaser_. For enabling this behavior in FACT-Finder Web Components you only have to include the `ff-product-teaser-campaign-processor` middleware into your `ff-communication` element as follows:
+Starting with FACT-Finder version 7.3.5-42 _feedback text campaigns_ can be configured as _teaser_. For enabling this behavior in FACT-Finder Web Components you only have to include the `ff-product-teaser-campaign-processor` middleware into your `ff-communication` element as follows:
 
 ```html
 <ff-communication>


### PR DESCRIPTION
Previously there was only a dedicated page.
Middleware page is intended to list all available modules therefore this addition.