### PR TITLE
fix description of getSimilarProducts()

### DIFF
--- a/markdown/1.x/en/api/ff-similar-products.api.md
+++ b/markdown/1.x/en/api/ff-similar-products.api.md
@@ -9,4 +9,4 @@ ___
 ### Methods
 | Name | Description |
 | ---- | ----------- |
-| **getSimilarProducts()** | Calls up the product recommendations again. |
+| **getSimilarProducts()** | Calls up the similar products again. |

--- a/markdown/3.x/en/api/ff-similar-products.api.md
+++ b/markdown/3.x/en/api/ff-similar-products.api.md
@@ -9,4 +9,4 @@ ___
 ### Methods
 | Name | Description |
 | ---- | ----------- |
-| **getSimilarProducts()** | Calls up the product recommendations again. |
+| **getSimilarProducts()** | Calls up the similar products again. |


### PR DESCRIPTION
Looked like a copy-and-paste error from `ff-recommendation`