### PR TITLE
[update-version-dropdown-to-1x"]

### DIFF
--- a/config.js
+++ b/config.js
@@ -7,5 +7,5 @@ export default {
     version: "7.2"
   },
   downloadToolUrl: "https://search-web-components.fact-finder.de/webcomponents-build-tool",
-  versions: [{name: "3.x", displayName: "3.x (latest)"}, {name: "1.x", displayName: "1.2"}]
+  versions: [{name: "3.x", displayName: "3.x (latest)"}, {name: "1.x", displayName: "1.x"}]
 }


### PR DESCRIPTION
as we have release `1.3.0` update  shown version number in version dropdown to `1.x`

![1 2 - 1 x](https://user-images.githubusercontent.com/42941766/57705910-fe7e2d80-7664-11e9-94f1-08d4a72a61e3.png)
