### PR TITLE
FFWEB-1135 Migrate ff tag cloud to lit element

### DIFF
--- a/markdown/1.x/en/core-result-dispatcher.md
+++ b/markdown/1.x/en/core-result-dispatcher.md
@@ -35,6 +35,7 @@ The function supplied in `fn` is invoked with data for the subscribed
 * `productDetail`
 * `similarProducts`
 * `productCampaign` - special
+* `tagCloud`
 
 These **topics** are dispatched in the current execution order.
 For example the `campaigns` are dispatched before the `asn`, but it is

--- a/markdown/3.x/en/api/ff-tag-cloud.api.md
+++ b/markdown/3.x/en/api/ff-tag-cloud.api.md
@@ -21,12 +21,4 @@ ___
 ### Methods
 | Name | Description |
 | ---- | ----------- |
-| **getTagCloud()**| Manually obtains the tag cloud entries from FACT-Finder. Useful when `disable-auto` is set to true and one wants to display the entries on a certain action. |
-
-### Mixins
-| Name | Description |
-| ---- | ----------- |
-| **--tag-cloud-container**| Mixin applied to the tag cloud wrapper container. Default: `display: flex;justify-content: space-around;flex-wrap: wrap;` |
-| **--tag-cloud-link**| Mixin applied to the tag cloud link. Default: `padding: 2px;` |
-
-
+| **getTagCloud()**| Manually obtains the tag cloud entries from FACT-Finder. Useful when `disable-auto` is set and one wants to display the entries on a certain action. |

--- a/markdown/3.x/en/api/ff-tag-cloud.api.md
+++ b/markdown/3.x/en/api/ff-tag-cloud.api.md
@@ -14,7 +14,7 @@ ___
 ### Events
 | Name | Description |
 | ---- | ----------- |
-| **entry-clicked** | Fired when a tag cloud entry is clicked and before the search for that entry is triggered. The event contains a reference to this element where you can set the property `ffPreventDefault` to skip its default action: Search for the clicked word. The event also contains an object with all the tag cloud entry information's: 1. query: The searched word. 2. count: The number of searches for that word. 3. params: The search parameters to execute a FACT-Finder search for that word. |
+| **entry-clicked** | Fired when a tag cloud entry is clicked and before the search for that entry is triggered. The event contains a reference to this element where you can set the property `ffPreventDefault` to skip its default action: Search for the clicked word. The event also contains an object with all the tag cloud entry information: 1. query: The searched word. 2. count: The number of searches for that word. 3. params: The search parameters to execute a FACT-Finder search for that word. |
 | **before-search** | Fired directly before the search for the tag cloud entry is executed. |
 | **dom-updated** | Fired every time the tag cloud element is re rendered. |
 

--- a/markdown/3.x/en/api/ff-tag-cloud.api.md
+++ b/markdown/3.x/en/api/ff-tag-cloud.api.md
@@ -9,12 +9,12 @@ ___
 | **gradient-color-start**&nbsp;(String) (default: "#294884") | Specifies the start color for the gradient of the searched words. |
 | **gradient-color-end** &nbsp;(String) (default: "#20b6e8") | Specifies the end color for the gradient of the searched words. |
 | **word-count**&nbsp;(Number) (default: 30) | Specifies the number of searched words to display. |
-| **disable-auto**&nbsp;(Boolean) (default: false) | Specifies whether the tag cloud entries should be automatically fetched on `attached` or not. |
+| **disable-auto**&nbsp;(Boolean) (default: false) | Specifies whether the tag cloud entries should be automatically fetched on `connectedCallback` or not. |
 
 ### Events
 | Name | Description |
 | ---- | ----------- |
-| **entry-clicked** | Fired when a tag cloud entry is clicked and before the search for that entry is triggered. The event contains a reference to this element where you can set the property `ffPreventDefault` to skip its default action: Search for the clicked word. The event also contains an object with all the tag cloud entry information: <br /> 1. query: The searched word <br /> 2. count: The number of searches for that word 3. params: The search parameters to execute a FACT-Finder search for that word. |
+| **entry-clicked** | Fired when a tag cloud entry is clicked and before the search for that entry is triggered. The event contains a reference to this element where you can set the property `ffPreventDefault` to skip its default action: Search for the clicked word. The event also contains an object with all the tag cloud entry information's: 1. query: The searched word. 2. count: The number of searches for that word. 3. params: The search parameters to execute a FACT-Finder search for that word. |
 | **before-search** | Fired directly before the search for the tag cloud entry is executed. |
 | **dom-updated** | Fired every time the tag cloud element is re rendered. |
 

--- a/markdown/3.x/en/core-result-dispatcher.md
+++ b/markdown/3.x/en/core-result-dispatcher.md
@@ -35,6 +35,7 @@ The function supplied in `fn` is invoked with data for the subscribed
 * `productDetail`
 * `similarProducts`
 * `productCampaign` - special
+* `tagCloud`
 
 These **topics** are dispatched in the current execution order.
 For example the `campaigns` are dispatched before the `asn`, but it is

--- a/markdown/3.x/en/ff-tag-cloud.md
+++ b/markdown/3.x/en/ff-tag-cloud.md
@@ -11,7 +11,7 @@ Basic usage:
 ```
 **NOTE:**
 Changing `word-count` when `disable-auto` is not set will trigger a tag cloud request to FACT-Finder followed by a DOM update. The default action of a click on a tag cloud child element will trigger a FACT-Finder search for that word. You can prevent this behavior by setting the `ffPreventDefault` on the `entry-clicked` event.
-`word-count` is the only property which triggers request to FACT-Finder when its value is changed.
+`word-count` is the only property which triggers a request to FACT-Finder when its value is changed.
 
 **Example snippet: Prevent default click event and redirect to different page:**
 

--- a/markdown/3.x/en/ff-tag-cloud.md
+++ b/markdown/3.x/en/ff-tag-cloud.md
@@ -10,7 +10,7 @@ Basic usage:
 <ff-tag-cloud min-font-size="10" max-font-size="40" word-count="50" unit="px"></ff-tag-cloud>
 ```
 **NOTE:**
-Changing `word-count` when `disable-auto` is not set will trigger a tag cloud request to FACT-Finder followed by a DOM update. The default action on a click of a tag cloud child element will trigger a FACT-Finder search for that word. You can prevent this behavior by setting the `ffPreventDefault` on the `entry-clicked` event.
+Changing `word-count` when `disable-auto` is not set will trigger a tag cloud request to FACT-Finder followed by a DOM update. The default action of a click on a tag cloud child element will trigger a FACT-Finder search for that word. You can prevent this behavior by setting the `ffPreventDefault` on the `entry-clicked` event.
 `word-count` is the only property which triggers request to FACT-Finder when its value is changed.
 
 **Example snippet: Prevent default click event and redirect to different page:**

--- a/markdown/3.x/en/ff-tag-cloud.md
+++ b/markdown/3.x/en/ff-tag-cloud.md
@@ -10,7 +10,7 @@ Basic usage:
 <ff-tag-cloud min-font-size="10" max-font-size="40" word-count="50" unit="px"></ff-tag-cloud>
 ```
 **NOTE:**
-Changes to any property of the element, except `disable-auto`, will trigger a tag cloud request to FACT-Finder followed by a DOM update. The default action on a click of a tag cloud child element will trigger a FACT-Finder search for that word. You can prevent this behavior by setting the `ffPreventDefault` on the `entry-clicked` event.
+Changing `word-count` property when `disable-auto` is set to false, will trigger a tag cloud request to FACT-Finder followed by a DOM update. The default action on a click of a tag cloud child element will trigger a FACT-Finder search for that word. You can prevent this behavior by setting the `ffPreventDefault` on the `entry-clicked` event.
 
 **Example snippet: Prevent default click event and redirect to different page:**
 

--- a/markdown/3.x/en/ff-tag-cloud.md
+++ b/markdown/3.x/en/ff-tag-cloud.md
@@ -11,6 +11,7 @@ Basic usage:
 ```
 **NOTE:**
 Changing `word-count` when `disable-auto` is not set will trigger a tag cloud request to FACT-Finder followed by a DOM update. The default action on a click of a tag cloud child element will trigger a FACT-Finder search for that word. You can prevent this behavior by setting the `ffPreventDefault` on the `entry-clicked` event.
+`word-count` is the only property which triggers request to FACT-Finder when its value is changed.
 
 **Example snippet: Prevent default click event and redirect to different page:**
 

--- a/markdown/3.x/en/ff-tag-cloud.md
+++ b/markdown/3.x/en/ff-tag-cloud.md
@@ -10,7 +10,7 @@ Basic usage:
 <ff-tag-cloud min-font-size="10" max-font-size="40" word-count="50" unit="px"></ff-tag-cloud>
 ```
 **NOTE:**
-Changing `word-count` property when `disable-auto` is set to false, will trigger a tag cloud request to FACT-Finder followed by a DOM update. The default action on a click of a tag cloud child element will trigger a FACT-Finder search for that word. You can prevent this behavior by setting the `ffPreventDefault` on the `entry-clicked` event.
+Changing `word-count` when `disable-auto` is not set will trigger a tag cloud request to FACT-Finder followed by a DOM update. The default action on a click of a tag cloud child element will trigger a FACT-Finder search for that word. You can prevent this behavior by setting the `ffPreventDefault` on the `entry-clicked` event.
 
 **Example snippet: Prevent default click event and redirect to different page:**
 


### PR DESCRIPTION
Documentation adjusted to migrated `ff-tag-cloud` components. Minor fixes (formatting and typos) done.