### PR TITLE
fix various typos

### DIFF
--- a/markdown/1.x/en/api/ff-search-feedback.api.md
+++ b/markdown/1.x/en/api/ff-search-feedback.api.md
@@ -15,7 +15,7 @@ ___
 | Name | Description |
 | ---- | ----------- |
 | **hide()** | Hides the element and sets the opened property to "false". Useful in cases you want to hide the element on detail page click. |
-| **show()** | Shows the element with it's former state. Useful in cases you hide the element on detail page click and want to show it again after navigating back on a SPA. |
+| **show()** | Shows the element with its former state. Useful in cases you hide the element on detail page click and want to show it again after navigating back on a SPA. |
 | **reset()** | Resets positive back to "true" and sets the value of the HTMLElement data-message to an empty string. Useful in cases where "resetOnToggle" or "resetOnSend" is not used. |
 
 ### Events

--- a/markdown/1.x/en/api/ff-tag-cloud.api.md
+++ b/markdown/1.x/en/api/ff-tag-cloud.api.md
@@ -14,14 +14,14 @@ ___
 ### Events
 | Name | Description |
 | ---- | ----------- |
-| **entry-clicked** | Fired when a tag cloud entry is clicked and before the search for that entry is triggered. The event contains a reference to this element where you can set the property `ffPreventDefault` to skip its default action: Search for the clicked word. The event also contains an object with all the tag cloud entry information's: <br /> 1. query: The searched word <br /> 2. count: The number of searches for that word 3. params: The search parameters to execute a FACT-Finder search for that word. |
+| **entry-clicked** | Fired when a tag cloud entry is clicked and before the search for that entry is triggered. The event contains a reference to this element where you can set the property `ffPreventDefault` to skip its default action: Search for the clicked word. The event also contains an object with all the tag cloud entry information: <br /> 1. query: The searched word <br /> 2. count: The number of searches for that word 3. params: The search parameters to execute a FACT-Finder search for that word. |
 | **before-search** | Fired directly before the search for the tag cloud entry is executed. |
 | **dom-updated** | Fired every time the tag cloud element is re rendered. |
 
 ### Methods
 | Name | Description |
 | ---- | ----------- |
-| **getTagCloud()**| Manually obtains the tag cloud entries from FACT-Finder. Useful when `disable-auto` is set to true and one want's to display the entries on a certain action. |
+| **getTagCloud()**| Manually obtains the tag cloud entries from FACT-Finder. Useful when `disable-auto` is set to true and one wants to display the entries on a certain action. |
 
 ### Mixins
 | Name | Description |

--- a/markdown/1.x/en/core-result-dispatcher.md
+++ b/markdown/1.x/en/core-result-dispatcher.md
@@ -18,7 +18,7 @@ ___
 The function supplied in `fn` is invoked with data for the subscribed
 `topic` when new data is available. The parameter `ctx` is optional
 
-#### All available topic's    
+#### All available topics
 * `result`
 * `campaigns` - special
 * `records`

--- a/markdown/1.x/en/documentation/currency-guide.md
+++ b/markdown/1.x/en/documentation/currency-guide.md
@@ -81,7 +81,7 @@ Most of the time `de-DE` and `en-GB` are covering everything needed.
 
 ---
 #### **currency-fields (String)**
-If you are importing multiple price fields like discount prices or something similar it's not sufficient to specify only the `currency-country-code` and the `currency-code`. In order to format additional price fields you have to tell FACT-Finder Web Components which fields should be processed. You can do that by setting the `currency-fields` attribute accordingly.  
+If you are importing multiple price fields like discount prices or something similar, it is not sufficient to specify only the `currency-country-code` and the `currency-code`. In order to format additional price fields you have to tell FACT-Finder Web Components which fields should be processed. You can do that by setting the `currency-fields` attribute accordingly.  
 
 **Example Usage**
 `<ff-communication currency-fields="discountPrice">`

--- a/markdown/1.x/en/documentation/ready-events.md
+++ b/markdown/1.x/en/documentation/ready-events.md
@@ -14,7 +14,7 @@ All our elements are utilizing the same Core functions described in our [ff-core
 
 Sometimes you want or have to change the data before all our elements being notified. This is where `ffReady` callback kicks in.
 
-If you are listening to the `ffReady` event it's guaranteed that your callback is invoked before all element callbacks are going to be invoked.
+If you are listening to the `ffReady` event, it is guaranteed that your callback is invoked before all element callbacks are going to be invoked.
 
 **Example usage**
 ```html
@@ -85,7 +85,7 @@ Even without using `ffReady` to trigger a search you stumble across an error mes
 
 _Required search params are not available: [url(globalSearchParameter): ""], [url(event): "undefined"], [channel: ""], [version:"NaN"]_
 
-If you are sure the message is not related to a custom js snippet it's possibly related to the order of elements.
+If you are sure the message is not related to a custom js snippet, it is possibly related to the order of elements.
 
 **IMPORTANT**
 
@@ -104,7 +104,7 @@ Let me show you a wrong example:
 <ff-communication url="https://some.ff.url" channel="aChannel" version="7.2"></ff-communication>
 ```
 
-The `ff-recommendation` element is responsible for querying the FACT-Finder recommendation API. At the time the element is _upgraded_ and sends its request, the 'ff-communication' hasn't published all it's configuration and therefore the request can't even be sent because no _URL_ and _CHANNEL_ information are available.
+The `ff-recommendation` element is responsible for querying the FACT-Finder recommendation API. At the time the element is _upgraded_ and sends its request, the 'ff-communication' hasn't published all its configuration and therefore the request can't even be sent because no _URL_ and _CHANNEL_ information are available.
 
 To fix this issue you have to place the `ff-communication` element before the `ff-recommendation` element:
 ```html
@@ -119,4 +119,4 @@ To fix this issue you have to place the `ff-communication` element before the `f
 **NOTE**
 We recommend putting the `ff-communication` element right after the `body` tag. This way no one can mess up the order.
 
-It's advisable to add a comment explaining this requirement.
+It is advisable to add a comment explaining this requirement.

--- a/markdown/1.x/en/documentation/template-engine.md
+++ b/markdown/1.x/en/documentation/template-engine.md
@@ -20,7 +20,7 @@ element is bound to an item in the records array.
 ### Data Binding Example
 
 ---
-By expanding the records array and one of it's items we can take a look at the fields returned by
+By expanding the records array and one of its items we can take a look at the fields returned by
 FACT-Finder. In this specific example product data is stored in an record object. All fields returned in
 this object are imported during the data feed process. You can configure which fields are returned in the
 FACT-Finder backend.
@@ -41,7 +41,7 @@ Take a look at the following data-binding example to see how to access the data.
 
 ---
 All bindings are resolved by the underlying template engine [mustache.js](https://github.com/janl/mustache.js/#mustachejs---logic-less-mustache-templates-with-javascript).
- For a bit more flexibility you can rely on some of it's functionality.
+ For a bit more flexibility you can rely on some of its functionality.
 
 You could do an **if** by using [this](https://github.com/janl/mustache.js/#false-values-or-empty-lists) syntax. 
 If the data is not formatted correctly, use the 

--- a/markdown/1.x/en/documentation/tracking-guide.md
+++ b/markdown/1.x/en/documentation/tracking-guide.md
@@ -82,7 +82,7 @@ In case a user is not logged in just leave it empty. **Never use a FakeId or som
 ---
 The `ff-checkout-tracking` element will send a checkout tracking request for each `ff-checkout-tracking-item` in its DOM. This element is meant to be generated on the server side after the checkout happened. For each product bought, you have to add an own `ff-checkout-tracking-item` with the according record-id and count. E.g. in the example below, five items of product _10321926_ were bought. 
 
-The tracking requests will be sent immediately after the element is parsed or, if you generate it in JavaScript code, when it's appended to the DOM. 
+The tracking requests will be sent immediately after the element is parsed or, if you generate it in JavaScript code, when it is appended to the DOM.
 ```html
 <ff-checkout-tracking>
    <ff-checkout-tracking-item record-id="10321926" count="5"></ff-checkout-tracking-item>

--- a/markdown/1.x/en/ff-carousel.md
+++ b/markdown/1.x/en/ff-carousel.md
@@ -104,7 +104,7 @@ It stops on the last slide. If 'infinite' is `true`, it will turn over to the fi
 
 ### show-bullets
 The 'Bullets' are a container which allows for a direct selection of a slide, much like a paging. It is represented as
-dots and can be styled with mix-in's. As default it is turned of.
+dots and can be styled with mix-ins. By default it is turned off.
 
 ```html
 <ff-record-list>

--- a/markdown/1.x/en/ff-header-navigation.md
+++ b/markdown/1.x/en/ff-header-navigation.md
@@ -217,7 +217,7 @@ with the `slot` attribute and set the value of the attribute with the following 
 
 `container-[direction]-[group name]`
 
-As shown in the example below, we define 4 `div's`. One for each slot in the "Bike" Group.
+As shown in the example below, we define 4 `div`s. One for each slot in the "Bike" Group.
 
 ```html
 <style>

--- a/markdown/3.x/en/api/ff-search-feedback.api.md
+++ b/markdown/3.x/en/api/ff-search-feedback.api.md
@@ -15,7 +15,7 @@ ___
 | Name | Description |
 | ---- | ----------- |
 | **hide()** | Hides the element and sets the opened property to "false". Useful in cases you want to hide the element on detail page click. |
-| **show()** | Shows the element with it's former state. Useful in cases you hide the element on detail page click and want to show it again after navigating back on a SPA. |
+| **show()** | Shows the element with its former state. Useful in cases you hide the element on detail page click and want to show it again after navigating back on a SPA. |
 | **reset()** | Resets positive back to "true" and sets the value of the HTMLElement data-message to an empty string. Useful in cases where "resetOnToggle" or "resetOnSend" is not used. |
 
 ### Events

--- a/markdown/3.x/en/api/ff-tag-cloud.api.md
+++ b/markdown/3.x/en/api/ff-tag-cloud.api.md
@@ -14,14 +14,14 @@ ___
 ### Events
 | Name | Description |
 | ---- | ----------- |
-| **entry-clicked** | Fired when a tag cloud entry is clicked and before the search for that entry is triggered. The event contains a reference to this element where you can set the property `ffPreventDefault` to skip its default action: Search for the clicked word. The event also contains an object with all the tag cloud entry information's: <br /> 1. query: The searched word <br /> 2. count: The number of searches for that word 3. params: The search parameters to execute a FACT-Finder search for that word. |
+| **entry-clicked** | Fired when a tag cloud entry is clicked and before the search for that entry is triggered. The event contains a reference to this element where you can set the property `ffPreventDefault` to skip its default action: Search for the clicked word. The event also contains an object with all the tag cloud entry information: <br /> 1. query: The searched word <br /> 2. count: The number of searches for that word 3. params: The search parameters to execute a FACT-Finder search for that word. |
 | **before-search** | Fired directly before the search for the tag cloud entry is executed. |
 | **dom-updated** | Fired every time the tag cloud element is re rendered. |
 
 ### Methods
 | Name | Description |
 | ---- | ----------- |
-| **getTagCloud()**| Manually obtains the tag cloud entries from FACT-Finder. Useful when `disable-auto` is set to true and one want's to display the entries on a certain action. |
+| **getTagCloud()**| Manually obtains the tag cloud entries from FACT-Finder. Useful when `disable-auto` is set to true and one wants to display the entries on a certain action. |
 
 ### Mixins
 | Name | Description |

--- a/markdown/3.x/en/core-result-dispatcher.md
+++ b/markdown/3.x/en/core-result-dispatcher.md
@@ -18,7 +18,7 @@ ___
 The function supplied in `fn` is invoked with data for the subscribed
 `topic` when new data is available. The parameter `ctx` is optional
 
-#### All available topic's    
+#### All available topics
 * `result`
 * `campaigns` - special
 * `records`

--- a/markdown/3.x/en/documentation/currency-guide.md
+++ b/markdown/3.x/en/documentation/currency-guide.md
@@ -81,7 +81,7 @@ Most of the time `de-DE` and `en-GB` are covering everything needed.
 
 ---
 #### **currency-fields (String)**
-If you are importing multiple price fields like discount prices or something similar it's not sufficient to specify only the `currency-country-code` and the `currency-code`. In order to format additional price fields you have to tell FACT-Finder Web Components which fields should be processed. You can do that by setting the `currency-fields` attribute accordingly.  
+If you are importing multiple price fields like discount prices or something similar, it is not sufficient to specify only the `currency-country-code` and the `currency-code`. In order to format additional price fields you have to tell FACT-Finder Web Components which fields should be processed. You can do that by setting the `currency-fields` attribute accordingly.  
 
 **Example Usage**
 `<ff-communication currency-fields="discountPrice">`

--- a/markdown/3.x/en/documentation/ready-events.md
+++ b/markdown/3.x/en/documentation/ready-events.md
@@ -14,7 +14,7 @@ All our elements are utilizing the same Core functions described in our [ff-core
 
 Sometimes you want or have to change the data before all our elements being notified. This is where `ffReady` callback kicks in.
 
-If you are listening to the `ffReady` event it's guaranteed that your callback is invoked before all element callbacks are going to be invoked.
+If you are listening to the `ffReady` event, it is guaranteed that your callback is invoked before all element callbacks are going to be invoked.
 
 **Example usage**
 ```html
@@ -85,7 +85,7 @@ Even without using `ffReady` to trigger a search you stumble across an error mes
 
 _Required search params are not available: [url(globalSearchParameter): ""], [url(event): "undefined"], [channel: ""], [version:"NaN"]_
 
-If you are sure the message is not related to a custom js snippet it's possibly related to the order of elements.
+If you are sure the message is not related to a custom js snippet, it is possibly related to the order of elements.
 
 **IMPORTANT**
 
@@ -104,7 +104,7 @@ Let me show you a wrong example:
 <ff-communication url="https://some.ff.url" channel="aChannel" version="7.2"></ff-communication>
 ```
 
-The `ff-recommendation` element is responsible for querying the FACT-Finder recommendation API. At the time the element is _upgraded_ and sends its request, the 'ff-communication' hasn't published all it's configuration and therefore the request can't even be sent because no _URL_ and _CHANNEL_ information are available.
+The `ff-recommendation` element is responsible for querying the FACT-Finder recommendation API. At the time the element is _upgraded_ and sends its request, the 'ff-communication' hasn't published all its configuration and therefore the request can't even be sent because no _URL_ and _CHANNEL_ information are available.
 
 To fix this issue you have to place the `ff-communication` element before the `ff-recommendation` element:
 ```html
@@ -119,4 +119,4 @@ To fix this issue you have to place the `ff-communication` element before the `f
 **NOTE**
 We recommend putting the `ff-communication` element right after the `body` tag. This way no one can mess up the order.
 
-It's advisable to add a comment explaining this requirement.
+It is advisable to add a comment explaining this requirement.

--- a/markdown/3.x/en/documentation/template-engine.md
+++ b/markdown/3.x/en/documentation/template-engine.md
@@ -20,7 +20,7 @@ element is bound to an item in the records array.
 ### Data Binding Example
 
 ---
-By expanding the records array and one of it's items we can take a look at the fields returned by
+By expanding the records array and one of its items we can take a look at the fields returned by
 FACT-Finder. In this specific example product data is stored in an record object. All fields returned in
 this object are imported during the data feed process. You can configure which fields are returned in the
 FACT-Finder backend.

--- a/markdown/3.x/en/documentation/tracking-guide.md
+++ b/markdown/3.x/en/documentation/tracking-guide.md
@@ -83,7 +83,7 @@ In case a user is not logged in just leave it empty. **Never use a FakeId or som
 ---
 The `ff-checkout-tracking` element will send a checkout tracking request for each `ff-checkout-tracking-item` in its DOM. This element is meant to be generated on the server side after the checkout happened. For each product bought, you have to add an own `ff-checkout-tracking-item` with the according record-id and count. E.g. in the example below, five items of product _10321926_ were bought. 
 
-The tracking requests will be sent immediately after the element is parsed or, if you generate it in JavaScript code, when it's appended to the DOM. 
+The tracking requests will be sent immediately after the element is parsed or, if you generate it in JavaScript code, when it is appended to the DOM.
 ```html
 <ff-checkout-tracking>
    <ff-checkout-tracking-item record-id="10321926" count="5"></ff-checkout-tracking-item>

--- a/markdown/3.x/en/ff-carousel.md
+++ b/markdown/3.x/en/ff-carousel.md
@@ -104,7 +104,7 @@ It stops on the last slide. If 'infinite' is `true`, it will turn over to the fi
 
 ### show-bullets
 The 'Bullets' are a container which allows for a direct selection of a slide, much like a paging. It is represented as
-dots and can be styled with mix-in's. As default it is turned of.
+dots and can be styled with mix-ins. By default it is turned off.
 
 ```html
 <ff-record-list>

--- a/src/views/download-view.js
+++ b/src/views/download-view.js
@@ -174,7 +174,7 @@ class DownloadView extends ReduxMixin(PolymerElement) {
                 <div class="col-md-6">
                     <h2>Navigation</h2>
                     <p style="padding-bottom: 22px">
-                        This are the common features a shop mostly needs.
+                        These are the common features a shop mostly needs.
                     </p>
                     <paper-toggle-button disabled="true" checked="true" on-active-changed="_toggleAll" class="toggle-button-all">
                         All


### PR DESCRIPTION
Just a few quick typo fixes. Mostly errors revolving around `'s`.
This PR does not claim to fix all typos.