### PR TITLE
FFWEB-1397 Enabled demo tab for `ff-filter-cloud`

### DIFF
--- a/markdown/3.x/en/ff-filter-cloud.md
+++ b/markdown/3.x/en/ff-filter-cloud.md
@@ -142,7 +142,7 @@ See the example below that shows how to create a filter element with clickable '
     }
 </script>
 <ff-filter-cloud unresolved>
-    <div data-template="filter" class="filter" onclick="userOnClick(e)">
+    <div data-template="filter" class="filter" onclick="userOnClick(event)">
         <span>{{element.name}}</span> <span class="btn-deselect">×</span>
     </div>
 </ff-filter-cloud>

--- a/src/data/3.x/api.js
+++ b/src/data/3.x/api.js
@@ -36,8 +36,7 @@ const api = {
         },
         "ff-filter-cloud": {
             path: `ff-filter-cloud`,
-            title: `Filter Cloud`,
-            noDemo: true
+            title: `Filter Cloud`
         },
         "ff-navigation": {
             path: `ff-navigation`,


### PR DESCRIPTION
In order to display Filter Cloud demo, it must be deployed to  https://search-web-components.fact-finder.de/, which will be done by @omikron-fp .