### PR TITLE
FFWEB-1428: Fix 404 on EventAggregatorLinks

### DIFF
--- a/src/views/api-view.js
+++ b/src/views/api-view.js
@@ -230,6 +230,10 @@ class ApiView extends ViewMixin(ReduxMixin(PolymerElement)) {
             return;
         }
 
+        if (this.subpage === `core-event-aggregator`) {
+            this._addScrollNavigation();
+        }
+
         const fileName = this.subpage;
 
         this.filePath = `markdown/${this.version}/${this.language}/${fileName}.md`;


### PR DESCRIPTION
_addScrollNavigation is only executed in ConnectedCallback when we are initially landed on the EventAggregator subpage. If not, the scroll listeners won't be attached at all.
This Fix adds _addScrollNavigation execution to page change observer