### PR TITLE
FFWEB-1447 Replaced `var` with `const` or `let` accordingly

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
                     scope: MyAppGlobals.rootPath
                 }).then(function (registration) {
                     registration.onupdatefound = function () {
-                        var installingWorker = registration.installing;
+                        const installingWorker = registration.installing;
                         installingWorker.onstatechange = function () {
                             switch (installingWorker.state) {
                                 case 'installed':
@@ -99,7 +99,7 @@
             });
         }
 
-        var process = process || {
+        window.process = window.process || {
             env: {}
         };
     </script>

--- a/markdown/1.x/en/core-event-aggregator.md
+++ b/markdown/1.x/en/core-event-aggregator.md
@@ -64,7 +64,7 @@ Removes a registered callback identified by its `key`
 ```html
 <script>
     document.addEventListener("ffReady", function () {
-        var key = factfinder.communication.FFCommunicationEventAggregator.addBeforeDispatchingCallback(function (event) {
+        const key = factfinder.communication.FFCommunicationEventAggregator.addBeforeDispatchingCallback(function (event) {
             if (event.type === "search") {
                 event["newConditionalHttpParam"] = "someValue";
             }
@@ -94,11 +94,11 @@ Now you can register/subscribe a callback to the ResultDispatcher with that topi
         }
     });
 
-    var key = factfinder.communication.ResultDispatcher.subscribe("myCustomSearch", function (resultData) {
+    const key = factfinder.communication.ResultDispatcher.subscribe("myCustomSearch", function (resultData) {
         // process the result
     });
 
-    var key2 = factfinder.communication.ResultDispatcher.addCallback("mySpecialElement", function (resultData) {
+    const key2 = factfinder.communication.ResultDispatcher.addCallback("mySpecialElement", function (resultData) {
         // process the result
     });
 </script>

--- a/markdown/1.x/en/core-result-dispatcher.md
+++ b/markdown/1.x/en/core-result-dispatcher.md
@@ -60,7 +60,7 @@ Unsubscribe during runtime from a specific topic
 <script>
     //listen for ffReady before HTML import is loaded or you'll miss the event
     document.addEventListener("ffReady", function () {
-        var key = factfinder.communication.ResultDispatcher.subscribe("result", function (resultData, event) {
+        const key = factfinder.communication.ResultDispatcher.subscribe("result", function (resultData, event) {
             // process the result and or the event
         });
 
@@ -78,7 +78,7 @@ This is similar to `subscribe()` but it is guaranteed to be executed
 <script>
     // listen for ffReady before HTML import is loaded or you'll miss the event
     document.addEventListener("ffReady", function () {
-        var key = factfinder.communication.ResultDispatcher.addCallback("asn", function (asnData) {
+        const key = factfinder.communication.ResultDispatcher.addCallback("asn", function (asnData) {
             // poke around in the asn data
         });
     });
@@ -94,7 +94,7 @@ registered callback.
 <script>
     // listen for ffReady before HTML import is loaded or you'll miss the event
     document.addEventListener("ffReady", function () {
-        var key = factfinder.communication.ResultDispatcher.addCallback("asn", function (asnData) {
+        const key = factfinder.communication.ResultDispatcher.addCallback("asn", function (asnData) {
             // poke around with asn data
         });
 

--- a/markdown/1.x/en/documentation/currency-guide.md
+++ b/markdown/1.x/en/documentation/currency-guide.md
@@ -44,8 +44,8 @@ This configurations adds the currency and all the number formatting to every pri
 ---
 FACT-Finder Web Components are using the [`Number.toLocaleString()`](https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString) function to format all price strings. If you want to format prices not covered by our attributes you can always use this function like:
 ````javascript
-var currencyCode = factfinder.communication.globalCommunicationParameter.currencyCode;
-var currencyCountryCode = factfinder.communication.globalCommunicationParameter.currencyCountryCode;
+const currencyCode = factfinder.communication.globalCommunicationParameter.currencyCode;
+const currencyCountryCode = factfinder.communication.globalCommunicationParameter.currencyCountryCode;
 
 parseFloat(priceStr).toLocaleString(currencyCountryCode, {
                         style: 'currency',

--- a/markdown/1.x/en/documentation/include-scripts.md
+++ b/markdown/1.x/en/documentation/include-scripts.md
@@ -19,8 +19,8 @@ The FACT-Finder Web Components build contains three files:
 
     <!-- Never change the order of the boilerplate -->
     <script>
-        var Polymer = Polymer || {};
-        Polymer.dom = 'shady';
+        window.Polymer = window.Polymer || {};
+        window.Polymer.dom = 'shady';
     </script>
     <script src="../bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
     <link rel="import" href="../bower_components/ff-web-components/dist/elements.build_with_dependencies.html">

--- a/markdown/1.x/en/documentation/tracking-with-js.md
+++ b/markdown/1.x/en/documentation/tracking-with-js.md
@@ -106,20 +106,20 @@ you can query FACT-Finder for product information.
 
 ```html
 <script>
-    var Polymer = Polymer || {};
-    Polymer.dom = 'shady';
+    window.Polymer = window.Polymer || {};
+    window.Polymer.dom = 'shady';
     
     document.addEventListener("WebComponentsReady", function () {
-        var trackingHelper = factfinder.communication.Util.trackingHelper;
-        var track = new factfinder.communication.Tracking12();
+        const trackingHelper = factfinder.communication.Util.trackingHelper;
+        const track = new factfinder.communication.Tracking12();
 
         factfinder.communication.ResultDispatcher.subscribe("productDetail", function (product) {
             if (product) {
                 // Retrieve field values based on field roles
-                var masterId = trackingHelper.getMasterArticleNumber(product);
-                var id = trackingHelper.getTrackingProductId(product);
-                var channel = factfinder.communication.globalSearchParameter.channel;
-                var sid = factfinder.common.localStorage.getItem("ff_sid");
+                const masterId = trackingHelper.getMasterArticleNumber(product);
+                const id = trackingHelper.getTrackingProductId(product);
+                const channel = factfinder.communication.globalSearchParameter.channel;
+                const sid = factfinder.common.localStorage.getItem("ff_sid");
                 
                 //track some information e.g. a checkout
                 track.checkout({

--- a/markdown/1.x/en/ff-compare.md
+++ b/markdown/1.x/en/ff-compare.md
@@ -86,11 +86,11 @@ trigger the compare service.
 <script>
     //alternativ via JavaScript
     function compare(){
-        var myRecordIds = [1001,1002,1003];
-        var compareElement = document.querySelector("ff-compare");
+        const myRecordIds = [1001,1002,1003];
+        const compareElement = document.querySelector("ff-compare");
 
         //dose NOT triggere the compare service
-        compareElement.recordIds =myRecordIds;
+        compareElement.recordIds = myRecordIds;
 
         //triggeres the compare service
         compareElement.compareRecords(myRecordIds);

--- a/markdown/1.x/en/ff-header-navigation.md
+++ b/markdown/1.x/en/ff-header-navigation.md
@@ -50,7 +50,7 @@ trigger the loading or you want to reload. In that case, set the `fetch-initial`
 ```html
 <ff-header-navigation fetch-initial="false"></ff-header-navigation>
 <script>
-    var nav = document.querySelector('ff-header-navigation');
+    const nav = document.querySelector('ff-header-navigation');
     Polymer.dom(nav).fetch();
 </script>
 ```

--- a/markdown/1.x/en/ff-navigation.md
+++ b/markdown/1.x/en/ff-navigation.md
@@ -226,7 +226,7 @@ You also need a logic outside of the element, to define when it will switch to t
 
 <script>
     window.addEventListener("resize", function (evt) {
-        var navigation = document.querySelector("ff-flyout-navigation");
+        const navigation = document.querySelector("ff-flyout-navigation");
         if (window.innerWidth < 600) {
             navigation.setAttribute("mobile", "true");
         } else {

--- a/markdown/1.x/en/ff-recommendation.md
+++ b/markdown/1.x/en/ff-recommendation.md
@@ -45,7 +45,7 @@ Set the record ID to load records that are recommended for that one product. Or 
 
 ```html
 <script>
-    var recommendationElement = document.querySelector("ff-recommendation");
+    const recommendationElement = document.querySelector("ff-recommendation");
     //This triggers the recommendation service request
     recommendationElement.recordId = "123456789";//Get a record id from a searchresult.
 </script>

--- a/markdown/1.x/en/ff-record-list-3d.md
+++ b/markdown/1.x/en/ff-record-list-3d.md
@@ -18,12 +18,12 @@ and iterate over each `ff-record` to apply the mouse over effect.
         // add an eventlistener to the ff-record-list event which is called everytime the HTML content was updated
         document.querySelector("ff-record-list").addEventListener("dom-updated", function (event) {
             // get the record list from the source attribute of the event callback.
-            var ffRecordListElement = event.srcElement;
+            const ffRecordListElement = event.srcElement;
             // get the record data from the record list.
-            var records = ffRecordListElement.querySelectorAll("ff-record");
+            const records = ffRecordListElement.querySelectorAll("ff-record");
             // iterating through all current visible records.
-            for (var i = 0; i < records.length; i++) {
-                var record = records[i];
+            for (let i = 0; i < records.length; i++) {
+                const record = records[i];
                 applyEffect(record);
             }
         });
@@ -39,13 +39,13 @@ Add the `mouseover` and `mouseout` effects to the record with the css selector v
 <script>
     function applyEffect(record) {
         if (record.style.display !== "none") {
-            var id = record.children[0].id;
+            const id = record.children[0].id;
 
             // getting the rating and information element and hiding it.
             $(this).find('#' + id + '_rating').hide();
             $(this).find('#' + id + '_info').hide();
 
-            var recordContainer = $("#" + id);
+            const recordContainer = $("#" + id);
 
             recordContainer.hover3d({
                 selector: '#' + id + "_record",

--- a/markdown/1.x/en/ff-similar-products.md
+++ b/markdown/1.x/en/ff-similar-products.md
@@ -31,7 +31,7 @@ In this element, you should use a `ff-record-list` to let the `ff-similar-produc
 Set this to trigger a call to the similar-products service for that specific record.
 ```html
 <script>
-    var similarProductsElement = document.querySelector("ff-similar-products");
+    const similarProductsElement = document.querySelector("ff-similar-products");
     //Triggers thesimilarProducts service
     similarProductsElement.recordId = "123456789";
 </script>

--- a/markdown/1.x/en/ff-suggest-without-input.md
+++ b/markdown/1.x/en/ff-suggest-without-input.md
@@ -73,7 +73,7 @@ The type of the event has to be `"suggest"` and as query we take the input value
 ```js
 // Calls the FACT-Finder suggest event.
 function raiseSuggestEvent(e) {
-    var inputValue = e.value;
+    const inputValue = e.value;
     if (inputValue && inputValue.length >= 2) {
         // this value is set to indicate if the current input value belongs to the received suggest response
         // e.g. suggest request takes 100ms while the user is deleting all chars in the input field
@@ -106,7 +106,7 @@ In this function we take the suggestion id to set the current search term for th
 ```js
 // Changes the term within the search box to the selected suggest item.
 function changeSearchTerm(e) {
-    var searchInput = e.suggestion.attributes.id;
+    const searchInput = e.suggestion.attributes.id;
     document.querySelector("input").value = searchInput;
 }
 

--- a/markdown/1.x/en/ff-suggest.md
+++ b/markdown/1.x/en/ff-suggest.md
@@ -173,7 +173,7 @@ assigning the event's `event.detail.record` to `ff-record`'s
 
 <script>
     document.querySelector("ff-suggest").addEventListener("suggest-product-record", function (event) {
-        var record = event.detail.record;
+        const record = event.detail.record;
         document.querySelector("detailPage ff-record").recordData = record;
     });
 </script>

--- a/markdown/1.x/en/ff-template.md
+++ b/markdown/1.x/en/ff-template.md
@@ -5,7 +5,7 @@ Set a **data** object for a template to store your data. With the "**{{}}**" mus
 ```html
 <script>
     function setTemplate1() {
-        var template1 = document.querySelector("#demoTemplate1");
+        const template1 = document.querySelector("#demoTemplate1");
         template1.data = {test: "This is my Test Data"};
     }
 </script>
@@ -22,7 +22,7 @@ You can also set a more complex model and access the data in it with the mustach
 ```html
 <script>
     function setTemplate2() {
-        var tmp = document.querySelector("#demoTemplate2");
+        const tmp = document.querySelector("#demoTemplate2");
         tmp.data = {
             product: {
                 name:"Super awsome Product",
@@ -53,7 +53,7 @@ If you have raw HTML in the data, e.g. configured in the FF-Backend as result fo
 ```html
 <script>
     function setTemplate3() {
-        var tmp = document.querySelector("#demoTemplate3");
+        const tmp = document.querySelector("#demoTemplate3");
         tmp.data = {
             product: {
                 name:"Super awsome Product",

--- a/markdown/3.x/en/core-event-aggregator.md
+++ b/markdown/3.x/en/core-event-aggregator.md
@@ -64,7 +64,7 @@ Removes a registered callback identified by its `key`
 ```html
 <script>
     document.addEventListener("ffReady", function () {
-        var key = factfinder.communication.FFCommunicationEventAggregator.addBeforeDispatchingCallback(function (event) {
+        const key = factfinder.communication.FFCommunicationEventAggregator.addBeforeDispatchingCallback(function (event) {
             if (event.type === "search") {
                 event["newConditionalHttpParam"] = "someValue";
             }
@@ -94,11 +94,11 @@ Now you can register/subscribe a callback to the ResultDispatcher with that topi
         }
     });
 
-    var key = factfinder.communication.ResultDispatcher.subscribe("myCustomSearch", function (resultData) {
+    const key = factfinder.communication.ResultDispatcher.subscribe("myCustomSearch", function (resultData) {
         // process the result
     });
 
-    var key2 = factfinder.communication.ResultDispatcher.addCallback("mySpecialElement", function (resultData) {
+    const key2 = factfinder.communication.ResultDispatcher.addCallback("mySpecialElement", function (resultData) {
         // process the result
     });
 </script>

--- a/markdown/3.x/en/core-result-dispatcher.md
+++ b/markdown/3.x/en/core-result-dispatcher.md
@@ -60,7 +60,7 @@ Unsubscribe during runtime from a specific topic
 <script>
     //listen for ffReady before HTML import is loaded or you'll miss the event
     document.addEventListener("ffReady", function () {
-        var key = factfinder.communication.ResultDispatcher.subscribe("result", function (resultData, event) {
+        const key = factfinder.communication.ResultDispatcher.subscribe("result", function (resultData, event) {
             // process the result and or the event
         });
 
@@ -78,7 +78,7 @@ This is similar to `subscribe()` but it is guaranteed to be executed
 <script>
     // listen for ffReady before HTML import is loaded or you'll miss the event
     document.addEventListener("ffReady", function () {
-        var key = factfinder.communication.ResultDispatcher.addCallback("asn", function (asnData) {
+        const key = factfinder.communication.ResultDispatcher.addCallback("asn", function (asnData) {
             // poke around in the asn data
         });
     });
@@ -94,7 +94,7 @@ registered callback.
 <script>
     // listen for ffReady before HTML import is loaded or you'll miss the event
     document.addEventListener("ffReady", function () {
-        var key = factfinder.communication.ResultDispatcher.addCallback("asn", function (asnData) {
+        const key = factfinder.communication.ResultDispatcher.addCallback("asn", function (asnData) {
             // poke around with asn data
         });
 

--- a/markdown/3.x/en/documentation/currency-guide.md
+++ b/markdown/3.x/en/documentation/currency-guide.md
@@ -44,8 +44,8 @@ This configurations adds the currency and all the number formatting to every pri
 ---
 FACT-Finder Web Components are using the [`Number.toLocaleString()`](https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString) function to format all price strings. If you want to format prices not covered by our attributes you can always use this function like:
 ````javascript
-var currencyCode = factfinder.communication.globalCommunicationParameter.currencyCode;
-var currencyCountryCode = factfinder.communication.globalCommunicationParameter.currencyCountryCode;
+const currencyCode = factfinder.communication.globalCommunicationParameter.currencyCode;
+const currencyCountryCode = factfinder.communication.globalCommunicationParameter.currencyCountryCode;
 
 parseFloat(priceStr).toLocaleString(currencyCountryCode, {
                         style: 'currency',

--- a/markdown/3.x/en/documentation/routing.md
+++ b/markdown/3.x/en/documentation/routing.md
@@ -8,7 +8,7 @@ In order to redirect all search events triggered on the homepage or other non-se
 ```javascript
 document.addEventListener("ffReady", function () {
     factfinder.communication.FFCommunicationEventAggregator.addBeforeDispatchingCallback(function (event) {
-        var isSearchEvent = event.type === "search" || event.type === "navigation-search";
+        const isSearchEvent = event.type === "search" || event.type === "navigation-search";
         if (isSearchEvent && !isSearchPage()) {
             delete event.type; // prevents the request from being sent before redirecting
 
@@ -19,7 +19,7 @@ document.addEventListener("ffReady", function () {
                 }
             });
 
-            var params = factfinder.common.dictToParameterString(event);
+            const params = factfinder.common.dictToParameterString(event);
             window.location.href = SEARCH_URL + params;
         }
     });

--- a/markdown/3.x/en/documentation/tracking-with-js.md
+++ b/markdown/3.x/en/documentation/tracking-with-js.md
@@ -107,16 +107,16 @@ you can query FACT-Finder for product information.
 ```html
 <script>
     document.addEventListener("WebComponentsReady", function () {
-        var trackingHelper = factfinder.communication.Util.trackingHelper;
-        var track = new factfinder.communication.Tracking12();
+        const trackingHelper = factfinder.communication.Util.trackingHelper;
+        const track = new factfinder.communication.Tracking12();
 
         factfinder.communication.ResultDispatcher.subscribe("productDetail", function (product) {
             if (product) {
                 // Retrieve field values based on field roles
-                var masterId = trackingHelper.getMasterArticleNumber(product);
-                var id = trackingHelper.getTrackingProductId(product);
-                var channel = factfinder.communication.globalSearchParameter.channel;
-                var sid = factfinder.common.localStorage.getItem("ff_sid");
+                const masterId = trackingHelper.getMasterArticleNumber(product);
+                const id = trackingHelper.getTrackingProductId(product);
+                const channel = factfinder.communication.globalSearchParameter.channel;
+                const sid = factfinder.common.localStorage.getItem("ff_sid");
                 
                 //track some information e.g. a checkout
                 track.checkout({

--- a/markdown/3.x/en/documentation/upgrade-guide.md
+++ b/markdown/3.x/en/documentation/upgrade-guide.md
@@ -14,8 +14,8 @@ There are only two major changes and some minor API changes to take care of when
     <!-- Before -->
     
     <script>
-        var Polymer = Polymer || {};
-        Polymer.dom = 'shady';
+        window.Polymer = window.Polymer || {};
+        window.Polymer.dom = 'shady';
     </script>
     <script src="../bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
     <link rel="import" href="../bower_components/ff-web-components/dist/elements.build_with_dependencies.html">

--- a/markdown/3.x/en/ff-compare.md
+++ b/markdown/3.x/en/ff-compare.md
@@ -86,11 +86,11 @@ trigger the compare service.
 <script>
     //alternativ via JavaScript
     function compare(){
-        var myRecordIds = [1001,1002,1003];
-        var compareElement = document.querySelector("ff-compare");
+        const myRecordIds = [1001,1002,1003];
+        const compareElement = document.querySelector("ff-compare");
 
         //dose NOT triggere the compare service
-        compareElement.recordIds =myRecordIds;
+        compareElement.recordIds = myRecordIds;
 
         //triggeres the compare service
         compareElement.compareRecords(myRecordIds);

--- a/markdown/3.x/en/ff-navigation.md
+++ b/markdown/3.x/en/ff-navigation.md
@@ -226,7 +226,7 @@ You also need a logic outside of the element, to define when it will switch to t
 
 <script>
     window.addEventListener("resize", function (evt) {
-        var navigation = document.querySelector("ff-flyout-navigation");
+        const navigation = document.querySelector("ff-flyout-navigation");
         if (window.innerWidth < 600) {
             navigation.setAttribute("mobile", "true");
         } else {

--- a/markdown/3.x/en/ff-recommendation.md
+++ b/markdown/3.x/en/ff-recommendation.md
@@ -44,7 +44,7 @@ Set the record ID to load records that are recommended for that one product. Or 
 
 ```html
 <script>
-    var recommendationElement = document.querySelector("ff-recommendation");
+    const recommendationElement = document.querySelector("ff-recommendation");
     //This triggers the recommendation service request
     recommendationElement.recordId = "123456789";//Get a record id from a searchresult.
 </script>

--- a/markdown/3.x/en/ff-record-list-3d.md
+++ b/markdown/3.x/en/ff-record-list-3d.md
@@ -18,12 +18,12 @@ and iterate over each `ff-record` to apply the mouse over effect.
         // add an eventlistener to the ff-record-list event which is called everytime the HTML content was updated
         document.querySelector("ff-record-list").addEventListener("dom-updated", function (event) {
             // get the record list from the source attribute of the event callback.
-            var ffRecordListElement = event.srcElement;
+            const ffRecordListElement = event.srcElement;
             // get the record data from the record list.
-            var records = ffRecordListElement.querySelectorAll("ff-record");
+            const records = ffRecordListElement.querySelectorAll("ff-record");
             // iterating through all current visible records.
-            for (var i = 0; i < records.length; i++) {
-                var record = records[i];
+            for (let i = 0; i < records.length; i++) {
+                const record = records[i];
                 applyEffect(record);
             }
         });
@@ -39,13 +39,13 @@ Add the `mouseover` and `mouseout` effects to the record with the css selector v
 <script>
     function applyEffect(record) {
         if (record.style.display !== "none") {
-            var id = record.children[0].id;
+            const id = record.children[0].id;
 
             // getting the rating and information element and hiding it.
             $(this).find('#' + id + '_rating').hide();
             $(this).find('#' + id + '_info').hide();
 
-            var recordContainer = $("#" + id);
+            const recordContainer = $("#" + id);
 
             recordContainer.hover3d({
                 selector: '#' + id + "_record",

--- a/markdown/3.x/en/ff-similar-products.md
+++ b/markdown/3.x/en/ff-similar-products.md
@@ -31,7 +31,7 @@ In this element, you should use a `ff-record-list` to let the `ff-similar-produc
 Set this to trigger a call to the similar-products service for that specific record.
 ```html
 <script>
-    var similarProductsElement = document.querySelector("ff-similar-products");
+    const similarProductsElement = document.querySelector("ff-similar-products");
     //Triggers thesimilarProducts service
     similarProductsElement.recordId = "123456789";
 </script>

--- a/markdown/3.x/en/ff-suggest-without-input.md
+++ b/markdown/3.x/en/ff-suggest-without-input.md
@@ -73,7 +73,7 @@ The type of the event has to be `"suggest"` and as query we take the input value
 ```js
 // Calls the FACT-Finder suggest event.
 function raiseSuggestEvent(e) {
-    var inputValue = e.value;
+    const inputValue = e.value;
     if (inputValue && inputValue.length >= 2) {
         // this value is set to indicate if the current input value belongs to the received suggest response
         // e.g. suggest request takes 100ms while the user is deleting all chars in the input field
@@ -106,7 +106,7 @@ In this function we take the suggestion id to set the current search term for th
 ```js
 // Changes the term within the search box to the selected suggest item.
 function changeSearchTerm(e) {
-    var searchInput = e.suggestion.attributes.id;
+    const searchInput = e.suggestion.attributes.id;
     document.querySelector("input").value = searchInput;
 }
 

--- a/markdown/3.x/en/ff-suggest.md
+++ b/markdown/3.x/en/ff-suggest.md
@@ -182,14 +182,14 @@ See the following example:
 <script>
     document.querySelector("ff-suggest").addEventListener("suggest-item-clicked", function (e) {
         // reference to the HTML element
-        var ffSuggestItem = e.detail.element;
+        const ffSuggestItem = e.detail.element;
         // reference to data
-        var suggestionData = e.detail.suggestion;
+        const suggestionData = e.detail.suggestion;
 
         // check if the ffSuggestItem matches the desired type for which you want to override the action
         if (suggestionData.type === "productName") {
             // configure in the FACT-Finder backend which fields should be returned in the attributes property!
-            var articleNr = ffSuggestItem.attributes["articleNr"];
+            const articleNr = ffSuggestItem.attributes["articleNr"];
             window.open("http://www.your-shop.example/"+articleNr, "_blank");
 
             // tell the suggest-item to skip its default action;
@@ -220,7 +220,7 @@ assigning the event's `event.detail.record` to `ff-record`'s
 
 <script>
     document.querySelector("ff-suggest").addEventListener("suggest-product-record", function (event) {
-        var record = event.detail.record;
+        const record = event.detail.record;
         document.querySelector("detailPage ff-record").recordData = record;
     });
 </script>

--- a/markdown/3.x/en/ff-template.md
+++ b/markdown/3.x/en/ff-template.md
@@ -5,7 +5,7 @@ Set a **data** object for a template to store your data. With the "**{{}}**" mus
 ```html
 <script>
     function setTemplate1() {
-        var template1 = document.querySelector("#demoTemplate1");
+        const template1 = document.querySelector("#demoTemplate1");
         template1.data = {test: "This is my Test Data"};
     }
 </script>
@@ -22,7 +22,7 @@ You can also set a more complex model and access the data in it with the mustach
 ```html
 <script>
     function setTemplate2() {
-        var tmp = document.querySelector("#demoTemplate2");
+        const tmp = document.querySelector("#demoTemplate2");
         tmp.data = {
             product: {
                 name:"Super awsome Product",
@@ -53,7 +53,7 @@ If you have raw HTML in the data, e.g. configured in the FF-Backend as result fo
 ```html
 <script>
     function setTemplate3() {
-        var tmp = document.querySelector("#demoTemplate3");
+        const tmp = document.querySelector("#demoTemplate3");
         tmp.data = {
             product: {
                 name:"Super awsome Product",

--- a/src/views/download-view.js
+++ b/src/views/download-view.js
@@ -413,8 +413,8 @@ class DownloadView extends ReduxMixin(PolymerElement) {
     }
 
     _toggleAll(event) {
-        var buttons = event.currentTarget.nextElementSibling.querySelectorAll(`div paper-toggle-button`);
-        for (var i = 0; i < buttons.length; i++) {
+        const buttons = event.currentTarget.nextElementSibling.querySelectorAll(`div paper-toggle-button`);
+        for (let i = 0; i < buttons.length; i++) {
             buttons[i].active = event.detail.value;
         }
     }
@@ -435,7 +435,7 @@ class DownloadView extends ReduxMixin(PolymerElement) {
     }
 
     _hasDifference(arr) {
-        var result = arr.filter(function (item) {
+        const result = arr.filter(function (item) {
             return item.active;
         });
         return !(result.length === arr.length || result.length === 0);

--- a/test/my-view1.html
+++ b/test/my-view1.html
@@ -32,10 +32,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script type="module">
       suite('my-view1 tests', function() {
         test('Number in circle should be 1', function() {
-          var myView = fixture('BasicView');
-          var circle = myView.shadowRoot.querySelector('.circle');
+            const myView = fixture('BasicView');
+            const circle = myView.shadowRoot.querySelector('.circle');
 
-          assert.equal(circle.textContent, '1');
+            assert.equal(circle.textContent, '1');
         });
       });
     </script>


### PR DESCRIPTION
Old `var Polymer = Polymer || {}` replaced with `window.Polymer = window.Polymer || {}` as `Polymer` is a global variable and cannot be replaced with let here.