### PR TITLE
FFWEB-1629 Remove obsolete references

### DIFF
--- a/markdown/3.x/en/core-event-aggregator.md
+++ b/markdown/3.x/en/core-event-aggregator.md
@@ -60,7 +60,7 @@ If you want to intercept a search request for example, you could do:
         });
     });
 </script>
-<link rel="import" href="path/to/ff-web-components.html">
+<script defer src="pathToFFWebComponents/dist/bundle.js"></script>
 ```
 
 ### `removeBeforeDispatchingCallback(key):boolean;`
@@ -79,7 +79,7 @@ Removes a registered callback identified by its `key`
         factfinder.communication.EventAggregator.removeBeforeDispatchingCallback(key);
     });
 </script>
-<link rel="import" href="path/to/ff-web-components.html">
+<script defer src="pathToFFWebComponents/dist/bundle.js"></script>
 ```
 
 ## Examples

--- a/markdown/3.x/en/core-result-dispatcher.md
+++ b/markdown/3.x/en/core-result-dispatcher.md
@@ -51,7 +51,7 @@ For example the `campaigns` are dispatched before the `asn`, but it is
         });
     });
 </script>
-<link rel="import" href="pathToHtmlImport/elements.build.with_dependencies.html">
+<script defer src="pathToFFWebComponents/dist/bundle.js"></script>
 ```    
 
 ### `unsubscribe(topic, key)`
@@ -69,7 +69,7 @@ Unsubscribe during runtime from a specific topic
         resultDispatcher.unsubscribe("result", key);
     });
 </script>
-<link rel="import" href="pathToHtmlImport/elements.build.with_dependencies.html">
+<script defer src="pathToFFWebComponents/dist/bundle.js"></script>
 ```
 
 ### `addCallback(topic, fn, context)`
@@ -86,7 +86,7 @@ This is similar to `subscribe()` but it is guaranteed to be executed
         });
     });
 </script>
-<link rel="import" href="pathToHtmlImport/elements.build.with_dependencies.html">
+<script defer src="pathToFFWebComponents/dist/bundle.js"></script>
 ```
 
 ### `removeCallback(topic, key)`
@@ -105,5 +105,5 @@ registered callback.
         factfinder.communication.ResultDispatcher.removeCallback("asn", key);
     });
 </script>
-<link rel="import" href="pathToHtmlImport/elements.build.with_dependencies.html">
+<script defer src="pathToFFWebComponents/dist/bundle.js"></script>
 ```

--- a/markdown/3.x/en/documentation/field-roles.md
+++ b/markdown/3.x/en/documentation/field-roles.md
@@ -96,7 +96,7 @@ Both EventListeners have to be declared before our scripts are loaded or you cou
         };
     });
 </script>
-<link rel="import" href="pathToHtmlImport/elements.build.with_dependencies.html">
+<script defer src="pathToFFWebComponents/dist/bundle.js"></script>
 ```
 
 **NOTICE:** We omitted some roles in this example but

--- a/markdown/3.x/en/documentation/tracking-with-js.md
+++ b/markdown/3.x/en/documentation/tracking-with-js.md
@@ -140,6 +140,5 @@ you can query FACT-Finder for product information.
     })
 </script>
 <script src="my-field-roles.js"></script>
-<script src="../bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
-<link rel="import" href="../bower_components/ff-web-components/dist/elements.build_with_dependencies.html">
+<script defer src="pathToFFWebComponents/dist/bundle.js"></script>
 ```

--- a/markdown/3.x/en/ff-record-list-3d.md
+++ b/markdown/3.x/en/ff-record-list-3d.md
@@ -109,8 +109,13 @@ done with the `{{id}}` syntax. Where each `div` container gets the id from its r
 
 ## On page load
 
-Finally trigger the `applyHover()` when the elements are loaded.
+Finally, trigger the `applyHover()` when the elements are loaded.
 
 ```html
-<link rel="import" href="elements.html" onload="applyHover();">
+<script>
+    document.addEventListener("WebComponentsReady", function () {
+        applyHover();
+    });
+</script>
+<script defer src="pathToFFWebComponents/dist/bundle.js"></script>
 ```


### PR DESCRIPTION
Removed `<link rel="import" href="pathToHtmlImport/elements.build.with_dependencies.html">` from code snippets as they are not supported in FACT-Finder WebComponents 3.x.