### PR TITLE
Add activation notice to documentation

### DIFF
--- a/markdown/3.x/en/documentation/install-dist.md
+++ b/markdown/3.x/en/documentation/install-dist.md
@@ -1,10 +1,13 @@
 ## Installation
 
 ---
+In order to use our Web Components library, **please contact our [Service Desk (service-desk@fact-finder.de)][1]
+for activation**!
+
 ### Using Node.js
 
 ---
-Add FACT-Finder Web Components as a dependency to your **package.json**.
+Add FACT-Finder Web Components as a dependency to your `package.json`.
 
 ```json
 {
@@ -21,3 +24,5 @@ Add FACT-Finder Web Components as a dependency to your **package.json**.
 2. Unzip the file
 3. In the `ff-web-components-3.x.x` directory locate the `dist` folder
 4. Copy the `dist` folder or its contents to your project
+
+[1]: mailto:service-desk@fact-finder.de?subject=Web%20Components%20Activation

--- a/markdown/3.x/en/faq.md
+++ b/markdown/3.x/en/faq.md
@@ -122,6 +122,18 @@ If this doesn't seem to solve the issue, please contact us for a custom solution
 ---
 
 ## Errors
+#### Error:
+
+`Access to XMLHttpRequest at 'https://my.fact-finder.de/FACT-Finder/Search.ff?query=*&channel=my_channel' has been
+blocked by CORS policy: Response to preflight request doesn't pass access control check: Redirect is not allowed for a
+preflight request.`
+
+#### Solution:
+In order to use our Web Components library, this must be activated on your FACT-Finder server.   
+**Please contact our
+[Service Desk (service-desk@fact-finder.de)][1] for activation**!
+
+---
 
 #### Error: 
 
@@ -129,3 +141,5 @@ If this doesn't seem to solve the issue, please contact us for a custom solution
 
 #### Solution:
 Add missing `defer` attribute on bundle.js like described [here](/documentation/3.x/include-scripts): `<script defer src="../dist/bundle.js"></script>`
+
+[1]: mailto:service-desk@fact-finder.de?subject=Web%20Components%20Activation

--- a/markdown/3.x/en/faq.md
+++ b/markdown/3.x/en/faq.md
@@ -129,9 +129,7 @@ blocked by CORS policy: Response to preflight request doesn't pass access contro
 preflight request.`
 
 #### Solution:
-In order to use our Web Components library, this must be activated on your FACT-Finder server.   
-**Please contact our
-[Service Desk (service-desk@fact-finder.de)][1] for activation**!
+In order to use our Web Components library, **please contact our [Service Desk (service-desk@fact-finder.de)][1] for activation**!
 
 ---
 


### PR DESCRIPTION
Unfortunately, we are often becoming tickets from customers who try our library before the Web Components security activation. Service Desk asked therefore for a notice in our documentation.