### PR TITLE
FFWEB-1850 require version and api

### DIFF
--- a/markdown/4.x/en/api/ff-communication.api.md
+++ b/markdown/4.x/en/api/ff-communication.api.md
@@ -6,9 +6,9 @@ _(`*` - required, `†` - conditionally required)_
 
 | Name | Description |
 |----|-----------|
-| **url**`*`&nbsp;(String) | Your FACT-Finder URL. Please note that the URL has to contain the FACT-Finder context name like: http://web-components.fact-finder.de/FACT-Finder-7.2/ |
-| **version**&nbsp;(String)&nbsp;(default: 7.2) | Your FACT-Finder version. Only major and minor version like "7.2" |
-| **api**&nbsp;(String)&nbsp;(default: `latest`) | Only relevant when `version="ng"`. The version of your FACT-Finder NG REST API. Possible values are `v2`, `v3` and `latest`. It is recommended to use an explicit version instead of `latest`. This avoids unintentionally breaking your application by updating your Web Components reference when a new API version becomes available. |
+| **url**`*`&nbsp;(String) | Your FACT-Finder URL. Please note that the URL has to contain the FACT-Finder context name like: `http://web-components.fact-finder.de/FACT-Finder-7.3/` |
+| **version**`*`&nbsp;(String) | Your FACT-Finder version. Only major and minor version like `7.3` or `ng`. |
+| **api**`†`&nbsp;(String) | Only relevant when `version="ng"`. The version of your FACT-Finder NG REST API. Allowed values are `v2`, `v3` and `v4`. |
 | **channel**`*`&nbsp;(String) | Your channel name. Has to be the same as the channel name configured in the FACT-Finder backend. |
 | **search-immediate**&nbsp;(Boolean) | If this property is present, FACT-Finder Web Components will start searching as soon as they are loaded. |
 | **use-url-parameters**&nbsp;(String) **Options**: &nbsp;"true", &nbsp;"false" (default: "true") | If set to false, FACT-Finder parameters are not pushed to the URL unless explicitly whitelisted. Note that this attribute has no effect when `only-search-params` is set. |

--- a/markdown/4.x/en/api/ff-communication.api.md
+++ b/markdown/4.x/en/api/ff-communication.api.md
@@ -1,12 +1,15 @@
 ## `ff-communication`
 ___
 ### Properties
+
+_(`*` - required, `†` - conditionally required)_
+
 | Name | Description |
 |----|-----------|
-| **url**&nbsp;(String) &nbsp;(default: empty) | Your FACT-Finder URL. Please note that the URL has to contain the FACT-Finder context name like: http://web-components.fact-finder.de/FACT-Finder-7.2/ |
+| **url**`*`&nbsp;(String) | Your FACT-Finder URL. Please note that the URL has to contain the FACT-Finder context name like: http://web-components.fact-finder.de/FACT-Finder-7.2/ |
 | **version**&nbsp;(String)&nbsp;(default: 7.2) | Your FACT-Finder version. Only major and minor version like "7.2" |
 | **api**&nbsp;(String)&nbsp;(default: `latest`) | Only relevant when `version="ng"`. The version of your FACT-Finder NG REST API. Possible values are `v2`, `v3` and `latest`. It is recommended to use an explicit version instead of `latest`. This avoids unintentionally breaking your application by updating your Web Components reference when a new API version becomes available. |
-| **channel**&nbsp;(String)&nbsp;(default: empty) | Your channel name. Has to be the same as the channel name configured in the FACT-Finder backend. |
+| **channel**`*`&nbsp;(String) | Your channel name. Has to be the same as the channel name configured in the FACT-Finder backend. |
 | **search-immediate**&nbsp;(Boolean) | If this property is present, FACT-Finder Web Components will start searching as soon as they are loaded. |
 | **use-url-parameters**&nbsp;(String) **Options**: &nbsp;"true", &nbsp;"false" (default: "true") | If set to false, FACT-Finder parameters are not pushed to the URL unless explicitly whitelisted. Note that this attribute has no effect when `only-search-params` is set. |
 | **default-query**&nbsp; (String) (default: '*') | Whenever a search is performed without a search query, this value will be used as default search term. |

--- a/markdown/4.x/en/documentation/upgrade-guide.md
+++ b/markdown/4.x/en/documentation/upgrade-guide.md
@@ -25,7 +25,8 @@ Only the changes that do not emit deprecation warnings are left to address **IF*
 
 | Breaking change | Chance of being affected | Required effort to fix | Deprecated since | Emits deprecation message |
 | --------------- | ------------------------ | ---------------------- | --- | --- |
-| Increment default FACT-Finder version vom `7.2` to `7.3` | Very low | Very Low | N/A | No |
+| Require `version` attribute | Close to zero | Close to zero | N/A | No |
+| Require `api` attribute | Medium | Close to zero | N/A | No |
 | Renaming of `ff-searchbox` attribute `hidesuggest-onblur` | Low | Very Low | `3.12.1` | Yes |
 | Removal of attribute `stamp-always` from `ff-record-list` and `ff-record` | Low | Very low | `3.14.1` | Yes |
 | Renaming of `FFCommunicationEventAggregator` | High | Very low | `3.10.0` | Yes |
@@ -39,24 +40,30 @@ Only the changes that do not emit deprecation warnings are left to address **IF*
 
 ### Detailed description of changes
 
-#### Increment default FACT-Finder version vom `7.2` to `7.3`
+#### Require `version` attribute
+
+**Note:** This change only affects you if you do not already specify the `version` attribute.
 
 | Chance of being affected | Required effort to fix | Deprecated since |
 | ------------------------ | ---------------------- | ---------------- |
-| Very low                 | Very low               | N/A              |
+| Close to zero            | Close to zero          | N/A              |
 
 Original issue:  
-https://github.com/FACT-Finder-Web-Components/ff-web-components/issues/48
+https://github.com/FACT-Finder-Web-Components/ff-web-components/issues/49
 
-WebComponents requires configuring of the targeted FACT-Finder version. This can be done explicitly by specifying the `version` attribute on the `ff-communication` element or implicitly by omitting it. When the `version` attribute is omitted, FACT-Finder `7.2` will be targeted.
+WebComponents requires configuring the targeted FACT-Finder version.
+This is usually done through the `ff-communication` element:
+```html
+<ff-communication version="7.3">
+```
 
-The default value is now `7.3`.
+The default value of `7.2` has become outdated and very uncommon.
+It seems no longer reasonable to define a default version at all as it becomes outdated fairly frequently.
 
-**Note:** This change only affects you if you do not specify the `version` attribute.
+From `4.0.0` there will be no default value anymore and `version` must be specified explicitly.
+WebComponents will throw an error if it fails to detect a version.
 
-It is recommended to always specify `version`.
-
-##### JavaScript
+##### HTML
 
 Before:
 ```html
@@ -66,6 +73,43 @@ Before:
 Now:
 ```html
 <ff-communication version="7.2"></ff-communication>
+```
+
+
+#### Require `api` attribute
+
+**Note:** This change only affects you if you do not already specify the `api` attribute.
+
+| Chance of being affected | Required effort to fix | Deprecated since |
+| ------------------------ | ---------------------- | ---------------- |
+| Medium                   | Close to zero          | N/A              |
+
+Original issue:  
+https://github.com/FACT-Finder-Web-Components/ff-web-components/issues/50
+
+WebComponents requires configuring the targeted FACT-Finder version.
+If the version is set to `ng`, the `api` attribute becomes relevant because FACT-Finder NG updates its API from time to time.
+
+This is usually done through the `ff-communication` element:
+```html
+<ff-communication version="ng" api="v3">`
+```
+
+It seems no longer reasonable to define a default API at all as it becomes outdated fairly frequently.
+
+From `4.0.0` there will be no default value anymore and `api` must be specified explicitly when `version="ng"`.
+WebComponents will throw an error if it fails to detect a value.
+
+##### HTML
+
+Before:
+```html
+<ff-communication version="ng"></ff-communication>
+```
+
+Now:
+```html
+<ff-communication version="ng" api="v4"></ff-communication>
 ```
 
 


### PR DESCRIPTION
Updates `4.0.0` migration guide and `ff-communication` API page.